### PR TITLE
Add NestJS to package.json/dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,4 +26,8 @@
       "eslint  --fix"
     ]
   }
+  "dependencies": {
+    "@nestjs/common": "^9.2.1",
+    "rxjs": "^7.8.0"
+  },
 }


### PR DESCRIPTION
Fix pcc-backend error "nest: command not found"