### PR TITLE
[CHORE] Add request-transformer to payment-noplugins.yaml

### DIFF
--- a/api-gateway/payment-noplugins.yaml
+++ b/api-gateway/payment-noplugins.yaml
@@ -1,7 +1,14 @@
 services:
   - name: PaymentAPI
-    url: https://ee1uqiu7x1.execute-api.ca-central-1.amazonaws.com/api/
+    host: ee1uqiu7x1.execute-api.ca-central-1.amazonaws.com
+    port: 443
+    protocol: https
+    path: /
     tags: [ ns.payment ]
+    plugins:
+      - name: request-transformer
+        tags: [ ns.payment]
+        config: {}
     routes:
       - tags:
           - OAS3_import


### PR DESCRIPTION
Aidan Cope: "In our test environment we have a global request-transformer plugin that adjusts the Host to align with what would be in production if preserve_host=true. This will only create an issue in our test instance, not our prod instance. To get around this add a 'request-transformer' plugin to your Service - so that it takes precedence over the global one."