### PR TITLE
[CCFPCM-0375] file parser

### DIFF
--- a/apps/backend/src/lambdas/utils/parseTDI.ts
+++ b/apps/backend/src/lambdas/utils/parseTDI.ts
@@ -3,9 +3,9 @@ import { TDI17Details, TDI34Details, DDFDetails } from '../../flat-files';
 
 export const parseTDI = (
   type: string,
-  fileContents: string,
   program: string,
-  fileName: string
+  fileName: string,
+  fileContents: string
 ): TDI34Details[] | TDI17Details[] | DDFDetails[] | [] => {
   const lines = fileContents?.split('\n').filter((l: string) => l);
   lines.splice(0, 1);
@@ -31,7 +31,7 @@ export const parseTDI = (
     return [];
   })();
 
-  // TODO: We don't check what the intput type is for the actual parsing! 
+  // TODO: We don't check what the intput type is for the actual parsing!
   const detailsArr = items.map((item, index) => {
     item.convertToJson(lines[index]);
     item.metadata = {
@@ -44,6 +44,9 @@ export const parseTDI = (
     return item;
   });
 
-  const typedTDArray = detailsArr as (TDI34Details[] | TDI17Details[] | DDFDetails[]);
+  const typedTDArray = detailsArr as
+    | TDI34Details[]
+    | TDI17Details[]
+    | DDFDetails[];
   return typedTDArray;
 };

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -9,7 +9,7 @@ import {
   Logger
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiOperation, ApiConsumes, ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiConsumes, ApiBody, ApiTags } from '@nestjs/swagger';
 import { ParseService } from './parse.service';
 import { AppLogger } from '../logger/logger.service';
 
@@ -58,27 +58,5 @@ export class ParseController {
       file.originalname,
       file.buffer
     );
-  }
-
-  @ApiOperation({
-    summary: 'Post Transaction Data'
-  })
-  @Post('garms-json')
-  @UseInterceptors(ClassSerializerInterceptor)
-  @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary'
-        }
-      }
-    }
-  })
-  @UseInterceptors(FileInterceptor('file'))
-  uploadGarmsJsonFile(@UploadedFile() file: Express.Multer.File) {
-    return this.parseService.readAndParseGarms(file.originalname, file.buffer);
   }
 }

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -1,20 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { parseGarms } from '../lambdas/utils/parseGarms';
 import { parseTDI } from '../lambdas/utils/parseTDI';
 import { AppLogger } from '../logger/logger.service';
 
 @Injectable()
 export class ParseService {
   constructor(@Inject(Logger) private readonly appLogger: AppLogger) {}
-  //TODO this is temporary for testing the parsed garms json only
-  async readAndParseGarms(filename: string, filebuffer: Buffer) {
-    try {
-      return parseGarms(JSON.parse(filebuffer.toString()), '', []);
-    } catch (e) {
-      this.appLogger.error(e);
-      throw e;
-    }
-  }
 
   async readAndParseFile(
     type: string,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -23,7 +23,7 @@ export class ParseService {
     data: Buffer
   ): Promise<unknown> {
     try {
-      return parseTDI(type, data.toString(), fileName, program);
+      return parseTDI(type, program, fileName, data.toString());
     } catch (err) {
       this.appLogger.error(err, 'Error parsing file');
       throw err;


### PR DESCRIPTION
[CCFPCM-0375](https://bcdevex.atlassian.net/browse/CCFPCM-0375)

Objective: 

Removed file upload for testing json (testing can now be done in the DB and previous changes have broken this endpoint). Left TDI parsing in place as parsed TDI in json format may still be useful in testing. 

Fixed swapped metadata fields on TDI34 parsing


