### PR TITLE
[CCFPCM-0393] non CAD cash

### DIFF
--- a/apps/backend/sample-files/transaction.json
+++ b/apps/backend/sample-files/transaction.json
@@ -17,7 +17,7 @@
     "payments": [
       {
         "amount": 20.0,
-        "forgein_currency_amount": 15.0,
+        "foreign_currency_amount": 15.0,
         "currency": "USD",
         "exchange_rate": 1.34,
         "payment_method": "CASH",

--- a/apps/backend/sample-files/transaction.json
+++ b/apps/backend/sample-files/transaction.json
@@ -4,7 +4,7 @@
     "transaction_date": "2023-01-01",
     "transaction_time": "13.33.31.875973",
     "fiscal_close_date": "2023-01-02",
-    " total_transaction_amount": 25.2,
+    "total_transaction_amount": 30.2,
     "void_indicator": false,
     "miscellaneous": {
       "employee_id": "SC61350"
@@ -16,16 +16,16 @@
     },
     "payments": [
       {
-        "amount": 10.2,
-        "currency": "CAD",
-        "exchange_rate": 0,
+        "amount": 20.0,
+        "forgein_currency_amount": 15.0,
+        "currency": "USD",
+        "exchange_rate": 1.34,
         "payment_method": "CASH",
         "payment_channel": "in-person"
       },
       {
-        "amount": 15.0,
+        "amount": 10.2,
         "currency": "CAD",
-        "exchange_rate": 0,
         "payment_method": "V",
         "payment_channel": "in-person",
         "terminal": {

--- a/apps/backend/src/database/migrations/1677697814581-migration.ts
+++ b/apps/backend/src/database/migrations/1677697814581-migration.ts
@@ -12,14 +12,13 @@ export class migration1677697814581 implements MigrationInterface {
     await queryRunner.query(`
         UPDATE payment
         SET foreign_currency_amount=amount
-        WHERE currency !='CAD'
-        
+        WHERE currency !='CAD' AND method NOT IN('AX', 'M', 'V', 'P')
     `);
 
     await queryRunner.query(`
         UPDATE payment
         SET amount=amount*(exchange_rate/100)
-        WHERE currency !='CAD'
+        WHERE currency !='CAD' AND method NOT IN('AX', 'M', 'V', 'P')
     `);
   }
 
@@ -27,13 +26,13 @@ export class migration1677697814581 implements MigrationInterface {
     await queryRunner.query(`
         UPDATE payment
         SET amount=amount/(exchange_rate/100)
-        WHERE currency !='CAD'
+        WHERE currency !='CAD' AND method NOT IN('AX', 'M', 'V', 'P')
     `);
 
     await queryRunner.query(`
         UPDATE payment
         SET foreign_currency_amount=null
-        WHERE method!='CAD'
+        WHERE currency !='CAD' AND method NOT IN('AX', 'M', 'V', 'P')
     `);
 
     await queryRunner.query(`

--- a/apps/backend/src/database/migrations/1677697814581-migration.ts
+++ b/apps/backend/src/database/migrations/1677697814581-migration.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1677697814581 implements MigrationInterface {
+  name = 'migration1677697814581';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE "payment" 
+        ADD "foreign_currency_amount" numeric(16,4)        
+    `);
+
+    await queryRunner.query(`
+        UPDATE payment
+        SET foreign_currency_amount=amount
+        WHERE currency !='CAD'
+        
+    `);
+
+    await queryRunner.query(`
+        UPDATE payment
+        SET amount=amount*(exchange_rate/100)
+        WHERE currency !='CAD'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE payment
+        SET amount=amount/(exchange_rate/100)
+        WHERE currency !='CAD'
+    `);
+
+    await queryRunner.query(`
+        UPDATE payment
+        SET foreign_currency_amount=null
+        WHERE method!='CAD'
+    `);
+
+    await queryRunner.query(`
+        ALTER TABLE "payment" 
+        DROP COLUMN "foreign_currency_amount"
+    `);
+  }
+}

--- a/apps/backend/src/lambdas/utils/parseGarms.ts
+++ b/apps/backend/src/lambdas/utils/parseGarms.ts
@@ -48,9 +48,13 @@ export const parseGarms = async (
               method: paymentMethods.find((pm) => {
                 return pm.sbc_code === method;
               })?.method,
-              amount: parseFloat(amount?.toFixed(2)),
+              currency: currency || 'CAD',
               exchange_rate,
-              currency
+              foreign_currency_amount: currency !== 'CAD' ? amount : undefined,
+              amount:
+                currency !== 'CAD' && exchange_rate
+                  ? parseFloat((amount * (exchange_rate / 100)).toFixed(2))
+                  : parseFloat(amount?.toFixed(2))
             });
           }
         ),

--- a/apps/backend/src/transaction/dto/payment.dto.ts
+++ b/apps/backend/src/transaction/dto/payment.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
+import { IsOptional, IsString, IsNotEmpty, IsNumber } from 'class-validator';
 import { PaymentChannel } from '../interface/transaction.interface';
 
 export class TerminalDTO {
@@ -44,18 +44,24 @@ export class PoSDTO {
 }
 
 export class PaymentDTO {
-  @ApiProperty({ description: 'Amount paid', example: 100.5 })
+  @ApiProperty({ description: 'Amount paid in CAD', example: 134.5 })
   @ApiProperty()
   @IsNumber()
   @IsNotEmpty()
   amount!: number;
+
+  @ApiProperty({ description: 'Foreign currency amount', example: 100.0 })
+  @ApiProperty()
+  @IsNumber()
+  @IsOptional()
+  foreign_currency_amount?: number;
 
   @ApiProperty({ description: 'Currency of payment', example: 'CAD' })
   @IsString()
   @IsNotEmpty()
   currency!: string;
 
-  @ApiProperty({ description: 'Exchange Rate', example: 1.0 })
+  @ApiProperty({ description: 'Exchange Rate', example: 1.345 })
   @IsNumber()
   @IsNotEmpty()
   exchange_rate!: number;

--- a/apps/backend/src/transaction/entities/payment.entity.ts
+++ b/apps/backend/src/transaction/entities/payment.entity.ts
@@ -32,8 +32,16 @@ export class PaymentEntity {
   })
   amount: number;
 
-  @Column({ nullable: true })
-  currency?: string;
+  @Column({
+    type: 'numeric',
+    precision: 16,
+    scale: 4,
+    nullable: true
+  })
+  foreign_currency_amount?: number;
+
+  @Column('varchar', { length: 3, nullable: false, default: 'CAD' })
+  currency: string;
 
   @Column({
     type: 'numeric',

--- a/apps/backend/src/transaction/interface/sbc_garms.ts
+++ b/apps/backend/src/transaction/interface/sbc_garms.ts
@@ -36,8 +36,9 @@ export interface SBCGarmsDistributions {
 export interface SBCGarmsPayment {
   method: string;
   amount: number;
-  exchange_rate?: number | undefined;
-  currency?: string | undefined;
+  foreign_currency_amount?: number;
+  exchange_rate?: number;
+  currency?: string;
 }
 
 export interface SBCGarmsSource {


### PR DESCRIPTION
[CCFPCM-0393](https://bcdevex.atlassian.net/browse/CCFPCM-0393)

**Objective:** 

- Account for USD during reconciliation

- Add column to record the calculated CAD amount in the case of non CAD payments (based on the provided exchange rate)

- Write migrations to include this column with the proper amounts in the db

- Write migration to update the current garms SBC exchange rate format to a standard exchange rate format. (Percentage, from foreign currency to CAD, not vice versa... ie: USD -> CAD = 1.34)

- Update garms parsing for proper exchange rate format

- Update API spec to validate proper exchange rate format

- Update cash reconciliation to use the calculated amount

- Add a getter to the payment class to return adjusted amount if it is exists, or, amount if not, and use this value for cash reconciliation 
