### PR TITLE
[CCFPCM-0404] TDI 17 location id -> pt_location_id

### DIFF
--- a/apps/backend/src/database/migrations/1677643656658-migration.ts
+++ b/apps/backend/src/database/migrations/1677643656658-migration.ts
@@ -1,6 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class migration1677643656658 implements MigrationInterface {
+  name = 'migration1677643656658';
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`        
         UPDATE pos_deposit

--- a/apps/backend/src/database/migrations/1677775665682-migration.ts
+++ b/apps/backend/src/database/migrations/1677775665682-migration.ts
@@ -1,6 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class migration1677775665682 implements MigrationInterface {
+  name = 'migration1677775665682';
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
         DELETE FROM PAYMENT WHERE AMOUNT = 0::numeric;

--- a/apps/backend/src/database/migrations/1677783207700-migration.ts
+++ b/apps/backend/src/database/migrations/1677783207700-migration.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1677783207700 implements MigrationInterface {
+  name = 'migration1677783207700';
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `alter table cash_deposit alter column "location_id" type character varying(5)`
+    );
+    await queryRunner.query(
+      `UPDATE cash_deposit SET location_id = CONCAT('0', location_id) WHERE LENGTH(location_id) = 1`
+    );
+
+    await queryRunner.query(
+      `UPDATE "cash_deposit" SET "location_id" = (select concat(transaction_type::varchar, location_id::varchar)::varchar)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" DROP COLUMN "transaction_type"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" RENAME COLUMN "location_id" TO "pt_location_id"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE cash_deposit ALTER COLUMN pt_location_id TYPE integer USING pt_location_id::integer;`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE cash_deposit ALTER COLUMN pt_location_id TYPE character varying(5) USING pt_location_id::varchar;`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" RENAME COLUMN "pt_location_id" TO "location_id"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" ADD COLUMN "transaction_type" character varying(3)`
+    );
+
+    await queryRunner.query(
+      `UPDATE cash_deposit SET transaction_type = LEFT(location_id, 3)::varchar`
+    );
+    await queryRunner.query(
+      `UPDATE cash_deposit SET location_id = RIGHT(location_id, 2)::varchar`
+    );
+    await queryRunner.query(
+      `ALTER TABLE cash_deposit ALTER COLUMN location_id TYPE integer USING cash_deposit.location_id::integer;`
+    );
+    await queryRunner.query(
+      `ALTER TABLE cash_deposit ALTER COLUMN transaction_type TYPE integer USING cash_deposit.transaction_type::integer;`
+    );
+  }
+}

--- a/apps/backend/src/database/migrations/2524636800000-migration.ts
+++ b/apps/backend/src/database/migrations/2524636800000-migration.ts
@@ -5,6 +5,7 @@ import { PaymentMethodEntity } from '../../transaction/entities';
 import { PaymentMethod } from '../../transaction/interface/transaction.interface';
 
 export class migration2524636800000 implements MigrationInterface {
+  name = 'migration2524636800000';
   public async up(queryRunner: QueryRunner): Promise<void> {
     const paymentMethodMasterFile = path.resolve(
       __dirname,

--- a/apps/backend/src/database/migrations/2524636800001-migration.ts
+++ b/apps/backend/src/database/migrations/2524636800001-migration.ts
@@ -5,6 +5,7 @@ import { LocationEntity } from '../../location/entities';
 import { ILocation } from '../../location/interface/location.interface';
 
 export class migration2524636800001 implements MigrationInterface {
+  name = 'migration2524636800001';
   public async up(queryRunner: QueryRunner): Promise<void> {
     const sbcLocationsMasterDataFile = path.resolve(
       __dirname,

--- a/apps/backend/src/deposits/cash-deposit.service.ts
+++ b/apps/backend/src/deposits/cash-deposit.service.ts
@@ -53,12 +53,12 @@ export class CashDepositService {
     const {
       program,
       date,
-      location: { location_id }
+      location: { pt_location_id }
     } = event;
 
     return await this.cashDepositRepo.find({
       where: {
-        location_id: location_id,
+        pt_location_id,
         metadata: { program: program },
         deposit_date: LessThanOrEqual(date),
         status: status
@@ -76,13 +76,13 @@ export class CashDepositService {
     const {
       date,
       program,
-      location: { location_id }
+      location: { pt_location_id }
     } = event;
 
     const dates = await this.cashDepositRepo.find({
       select: { deposit_date: true },
       where: {
-        location_id,
+        pt_location_id,
         metadata: { program },
         deposit_date: LessThanOrEqual(date)
       },
@@ -116,13 +116,13 @@ export class CashDepositService {
     const {
       date,
       program,
-      location: { location_id }
+      location: { pt_location_id }
     } = event;
 
     const dates = await this.cashDepositRepo.find({
       select: { deposit_date: true },
       where: {
-        location_id,
+        pt_location_id,
         metadata: { program },
         deposit_date: LessThanOrEqual(date)
       },

--- a/apps/backend/src/deposits/entities/cash-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/cash-deposit.entity.ts
@@ -28,10 +28,7 @@ export class CashDepositEntity {
   deposit_date: string;
 
   @Column({ type: 'int4' })
-  transaction_type: number;
-
-  @Column({ type: 'int4' })
-  location_id: number;
+  pt_location_id: number;
 
   @Column({ nullable: true })
   deposit_time: string;

--- a/apps/backend/src/flat-files/tdi17/TDI17Details.ts
+++ b/apps/backend/src/flat-files/tdi17/TDI17Details.ts
@@ -13,8 +13,7 @@ export interface ITDI17Details extends IFixedWidthRecord<ITDI17Details> {
   ministry_no: string;
   program_code: string;
   deposit_date: string;
-  transaction_type: number;
-  location_id: number;
+  pt_location_id: number;
   deposit_time: string;
   seq_no: string;
   location_desc: string;
@@ -35,7 +34,7 @@ export class TDI17Details
   implements ITDI17Details
 {
   public static readonly resourceType = 'TDIDetails';
-
+  /*eslint-disable @typescript-eslint/no-explicit-any*/
   constructor(init?: any) {
     super(init);
   }
@@ -84,22 +83,13 @@ export class TDI17Details
     this.resource.deposit_date = data;
   }
 
-  @Column({ start: 15, width: 3 })
-  public get transaction_type(): number {
-    return this.resource.transaction_type;
+  public set pt_location_id(data: number) {
+    this.resource.pt_location_id = data;
   }
 
-  public set transaction_type(data: number) {
-    this.resource.transaction_type = data;
-  }
-
-  @Column({ start: 18, width: 2, format: { type: DataType.Integer } })
-  public get location_id(): number {
-    return this.resource.location_id;
-  }
-
-  public set location_id(data: number) {
-    this.resource.location_id = data;
+  @Column({ start: 15, width: 5 })
+  public get pt_location_id(): number {
+    return this.resource.pt_location_id;
   }
 
   @Column({ start: 20, width: 4, format: { type: DataType.Time } })

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -37,7 +37,10 @@ export const handler = async (
     event.location_ids.length === 0
       ? await locationService.getLocationsBySource(event.program)
       : await locationService.getLocationsByID(event);
-
+  const pt_locations =
+    event.location_ids.length === 0
+      ? await locationService.getPTLocationsBySource(event.program)
+      : await locationService.getPTLocationsByID(event);
   const reconcile = async (event: ReconciliationEventInput) => {
     const dates = getFiscalDatesForPOS(event);
 
@@ -56,6 +59,8 @@ export const handler = async (
           })
         );
       }
+    }
+    for (const location of pt_locations) {
       const cashDates = await cashRecon.getDatesForReconciliation({
         ...event,
         date: event.fiscal_close_date,

--- a/apps/backend/src/location/location.service.ts
+++ b/apps/backend/src/location/location.service.ts
@@ -30,6 +30,39 @@ export class LocationService {
     });
     return merchant_ids.map((itm) => itm.merchant_id) as number[];
   }
+
+  public async getPTLocationsByID(
+    event: ReconciliationEventInput
+  ): Promise<LocationEntity[]> {
+    return await this.locationRepo.find({
+      select: {
+        pt_location_id: true,
+        description: true
+      },
+      where: {
+        source_id: event.program,
+        method: `${LocationEnum.Bank}`,
+        pt_location_id: In(event.location_ids)
+      },
+      order: {
+        pt_location_id: 'ASC'
+      }
+    });
+  }
+
+  public async getPTLocationsBySource(
+    source: Ministries
+  ): Promise<LocationEntity[]> {
+    return await this.locationRepo.find({
+      where: {
+        source_id: source,
+        method: `${LocationEnum.Bank}`
+      },
+      order: {
+        location_id: 'ASC'
+      }
+    });
+  }
   public async getLocationsByID(
     event: ReconciliationEventInput
   ): Promise<LocationEntity[]> {


### PR DESCRIPTION
[CCFPCM-0000](https://bcdevex.atlassian.net/browse/CCFPCM-0000)

Objective: 

TDI 17 “transaction type“ and “location_id“ should be a single column/field called pt_location_id. 

Update this in the TDI17 parser, update cash match location lookup, and write migrations to fix this issue.
