### PR TITLE
[FIX] cash location_ids

### DIFF
--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -1,6 +1,6 @@
 {
   "fiscal_start_date": "2023-01-01",
-  "fiscal_close_date": "2023-02-27",
+  "fiscal_close_date": "2023-03-02",
   "program": "SBC",
   "location_ids": []
 }

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -37,10 +37,14 @@ export const handler = async (
     event.location_ids.length === 0
       ? await locationService.getLocationsBySource(event.program)
       : await locationService.getLocationsByID(event);
+  appLogger.log(`Found ${locations.length} pos_deposit locations`);
   const pt_locations =
     event.location_ids.length === 0
       ? await locationService.getPTLocationsBySource(event.program)
       : await locationService.getPTLocationsByID(event);
+
+  appLogger.log(`Found ${pt_locations.length} cash_deposit locations`);
+
   const reconcile = async (event: ReconciliationEventInput) => {
     const dates = getFiscalDatesForPOS(event);
 

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -87,6 +87,10 @@ export const handler = async (
           date,
           location
         });
+        console.log(`SUMMARY FOR: ${location.description}`);
+        console.table(
+          await reportingService.cashReportByLocation(location.location_id)
+        );
         console.table(matched);
         appLogger.log('-------------------------------------------------');
         appLogger.log(

--- a/apps/backend/src/location/location.service.ts
+++ b/apps/backend/src/location/location.service.ts
@@ -37,12 +37,13 @@ export class LocationService {
     return await this.locationRepo.find({
       select: {
         pt_location_id: true,
+        location_id: true,
         description: true
       },
       where: {
         source_id: event.program,
         method: `${LocationEnum.Bank}`,
-        pt_location_id: In(event.location_ids)
+        location_id: In(event.location_ids)
       },
       order: {
         pt_location_id: 'ASC'


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/CCFPCM-0000)

**Objective:** 

- When the column for the pt_location_ids in the cash deposit table was last updated, the logic for the location lookup for cash reconciliation had an error if a location id was passed in with the reconciliation event. If a location_id is passed in to the recon event, this location_id should be used to lookup pt_location_ids, rather than expecting a pt_location_id to be passed in with the event.


