### PR TITLE
[FIX] pos-deposit-match

### DIFF
--- a/apps/backend/src/deposits/cash-deposit.service.ts
+++ b/apps/backend/src/deposits/cash-deposit.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Raw, Repository } from 'typeorm';
+import { In, LessThan, Raw, Repository } from 'typeorm';
 import { CashDepositEntity } from './entities/cash-deposit.entity';
 import { MatchStatus } from '../common/const';
 import { mapLimit } from '../common/promises';
@@ -140,5 +140,20 @@ export class CashDepositService {
       id: deposit.id
     });
     return await this.cashDepositRepo.save({ ...depositEntity, ...deposit });
+  }
+
+  async findExceptions(
+    date: string,
+    program: Ministries,
+    location: LocationEntity
+  ) {
+    return await this.cashDepositRepo.find({
+      where: {
+        pt_location_id: location.pt_location_id,
+        metadata: { program: program },
+        deposit_date: LessThan(date),
+        status: In([MatchStatus.PENDING, MatchStatus.IN_PROGRESS])
+      }
+    });
   }
 }

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -141,7 +141,7 @@ const runCashReconciliation = async (
       );
 
       appLogger.log(
-        `EXCEPTIONS: ${exceptions?.length ?? 0} found for: ${
+        `EXCEPTIONS: ${exceptions?.payments.length ?? 0} found for: ${
           location.description
         } (${location.location_id}) on ${date}`,
         CashReconciliationService.name

--- a/apps/backend/src/reconciliation/cash-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/cash-reconciliation.service.ts
@@ -59,6 +59,13 @@ export class CashReconciliationService {
       dateRange,
       location
     );
+    if (depositDates.length < 2) {
+      this.appLogger.log(
+        'No past due dates found',
+        CashReconciliationService.name
+      );
+      return;
+    }
     const dates = {
       currentDate: depositDates[0],
       pastDueDate: depositDates[2]

--- a/apps/backend/src/reconciliation/cash-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/cash-reconciliation.service.ts
@@ -132,7 +132,7 @@ export class CashReconciliationService {
       payment: AggregatedPayment,
       deposit: CashDepositEntity
     ) => {
-      if (Math.abs(deposit.deposit_amt_cdn - payment.amount) < 0.01) {
+      if (Math.abs(deposit.deposit_amt_cdn - payment.amount) < 0.001) {
         this.appLogger.log(
           `MATCH: payment: ${payment.amount} --> deposit: ${deposit.deposit_amt_cdn}`,
           CashReconciliationService.name

--- a/apps/backend/src/reconciliation/pos-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/pos-reconciliation.service.ts
@@ -138,10 +138,13 @@ export class POSReconciliationService {
       `MATCHES: ${matches.length}`,
       POSReconciliationService.name
     );
-    matches.forEach(async (itm) => {
-      await this.paymentService.updatePayment(itm.payment);
-      await this.posDepositService.update(itm.deposit);
-    });
+    await Promise.all(
+      matches.map(async (itm) => {
+        const payments = await this.paymentService.updatePayment(itm.payment);
+        const deposits = await this.posDepositService.update(itm.deposit);
+        return { payments, deposits };
+      })
+    );
   }
   /**
    * @param exceptions

--- a/apps/backend/src/reporting/reporting.service.ts
+++ b/apps/backend/src/reporting/reporting.service.ts
@@ -20,7 +20,6 @@ import { ExcelExportService } from '../excelexport/excelexport.service';
 import { LocationEntity } from '../location/entities';
 import { LocationService } from '../location/location.service';
 import { AppLogger } from '../logger/logger.service';
-import { ReconciliationEvent } from '../reconciliation/types';
 import { PaymentEntity } from '../transaction/entities';
 import { PaymentService } from '../transaction/payment.service';
 
@@ -281,8 +280,8 @@ export class ReportingService {
 
     const posPayments: PaymentEntity[] = await Promise.all(
       await this.paymentService.findPosPayments(
-        location,
-        config.period.to.toString()
+        config.period.to.toString(),
+        location
       )
     );
 
@@ -304,11 +303,11 @@ export class ReportingService {
     );
 
     const posDeposits: POSDepositEntity[] = await Promise.all(
-      await this.posDepositService.findPOSDeposits({
-        program: config.program,
-        date: config.period.to.toString(),
-        location: location
-      } as ReconciliationEvent)
+      await this.posDepositService.findPOSDeposits(
+        config.period.to.toString(),
+        config.program,
+        location
+      )
     );
 
     const parsedPosDepositDetails = posDeposits.map((itm: POSDepositEntity) =>

--- a/apps/backend/src/transaction/payment.service.ts
+++ b/apps/backend/src/transaction/payment.service.ts
@@ -56,7 +56,8 @@ export class PaymentService {
             payments: []
           };
         }
-        acc[key].amount += payment.amount;
+        //TODO  I think we need to set the db precision to 2 decimal places to avoid this extra formatting??
+        acc[key].amount += parseFloat(payment.amount.toFixed(2));
         acc[key].payments.push(payment);
         return acc;
       },
@@ -113,7 +114,7 @@ export class PaymentService {
         transaction: {
           location_id: location.location_id,
           fiscal_close_date: Raw(
-            (alias) => `${alias} >= :pastDueDate AND ${alias} <= :currentDate`,
+            (alias) => `${alias} >= :pastDueDate AND ${alias} < :currentDate`,
             { pastDueDate, currentDate }
           )
         }

--- a/apps/backend/src/transaction/payment.service.ts
+++ b/apps/backend/src/transaction/payment.service.ts
@@ -17,10 +17,12 @@ export class PaymentService {
   ) {}
 
   async findPosPayments(
+    date: string,
     location: LocationEntity,
-    date: string
+    status?: MatchStatus
   ): Promise<PaymentEntity[]> {
     const pos_payment_methods = ['AX', 'V', 'P', 'M'];
+    const paymentStatus = status ? status : In(MatchStatusAll);
 
     return await this.paymentRepo.find({
       where: {
@@ -28,6 +30,7 @@ export class PaymentService {
           transaction_date: date,
           location_id: location.location_id
         },
+        status: paymentStatus,
         method: In(pos_payment_methods)
       },
       relations: ['transaction', 'payment_method'],
@@ -156,7 +159,7 @@ export class PaymentService {
     return await this.paymentRepo.save({
       ...paymentEntity,
       status: MatchStatus.MATCH,
-      pos_deposit_id: deposit
+      pos_deposit_match: deposit
     });
   }
 

--- a/apps/backend/src/transaction/transaction.service.ts
+++ b/apps/backend/src/transaction/transaction.service.ts
@@ -1,14 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { TransactionEntity, PaymentEntity } from './entities';
+import { TransactionEntity } from './entities';
 import { PaymentService } from './payment.service';
 import { mapLimit } from '../common/promises';
 import { AppLogger } from '../logger/logger.service';
-import {
-  PosPaymentPosDepositPair,
-  ReconciliationEvent
-} from '../reconciliation/types';
 
 @Injectable()
 export class TransactionService {
@@ -39,29 +35,5 @@ export class TransactionService {
       .select('transaction.source_file_name')
       .distinct()
       .getRawMany();
-  }
-
-  async findPosPayments(event: ReconciliationEvent) {
-    return await this.paymentService.findPosPayments(
-      event.location,
-      event.date
-    );
-  }
-
-  // Error handling?
-  async markPosPaymentsAsMatched(
-    posPaymentDepostPair: PosPaymentPosDepositPair[]
-  ): Promise<PaymentEntity[]> {
-    return await Promise.all(
-      posPaymentDepostPair.map(
-        async ({ payment, deposit }) =>
-          await this.paymentService.markPosPaymentsAsMatched(payment, deposit)
-      )
-    );
-  }
-
-  //TODO - Remove this and call the Payment Service directly from the POS reconciliation service
-  async updatePaymentStatus(payment: PaymentEntity): Promise<PaymentEntity> {
-    return await this.paymentService.updatePayment(payment);
   }
 }


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

**Objective:** 

- pos_deposit id was not being recorded. 

- added in second layer of matching to match by day, after matching by 5 minutes initially for POS.

- cleaned up the reconcile lambda logging

- (attempted) to simplify some of the pos reconciliation functions for easier unit testing

- removed unused or unnecessary functions
