### PR TITLE
[CCFPCM-0445]: Update reporting with new criteria for cash

### DIFF
--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-02-28"
+    "to": "2023-03-01"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/src/reporting/styles.ts
+++ b/apps/backend/src/reporting/styles.ts
@@ -28,33 +28,14 @@ export const placement = (mergeRange: string): Placement => {
   };
 };
 
-export const borderStyle: Partial<Excel.Borders> = {
-  top: { style: 'thin', color: { argb: 'FF000000' } },
-  left: { style: 'thin', color: { argb: 'FF000000' } },
-  bottom: { style: 'thin', color: { argb: 'FF000000' } },
-  right: { style: 'thin', color: { argb: 'FF000000' } }
-};
-
 export const columnStyle: Partial<Excel.Style> = {
   font: {
     ...fontStyle,
     bold: true
-  },
-  fill: {
-    type: 'pattern',
-    pattern: 'solid',
-    fgColor: { argb: 'FFFFFFFF' }
-  },
-  border: { ...borderStyle }
+  }
 };
 export const rowCommonStyle: Partial<Excel.Style> = {
-  fill: {
-    type: 'pattern',
-    pattern: 'solid',
-    fgColor: { argb: 'FFFFFFFF' }
-  },
-  font: { ...fontStyle },
-  border: { ...borderStyle }
+  font: { ...fontStyle }
 };
 
 export const rowStyle = (exceptions?: boolean): Partial<Excel.Style> => {
@@ -65,8 +46,7 @@ export const rowStyle = (exceptions?: boolean): Partial<Excel.Style> => {
         pattern: 'solid',
         fgColor: { argb: '1AE78587' }
       },
-      font: { ...fontStyle },
-      border: { ...borderStyle }
+      font: { ...fontStyle }
     };
   }
   return rowCommonStyle;


### PR DESCRIPTION
[CCFPCM-0445](https://bcdevex.atlassian.net/browse/CCFPCM-0445)

**Objective:** 

Show only cash deposits which were made on the date that the report is being generated.  If there is a deposit on that date, show the deposit information as well as the corresponding cash payments. 

ALL cash payments which are PENDING or IN_PROGRESS should also be shown on the report which occurred between the report json "period.to" and "period.from" dates

Exceptions and Matches should appear on the report only once, on the corresponding deposit date which matches the report "config.period.to" date.


