### PR TITLE
[CHORE] refine logging process to fully utilize winston

### DIFF
--- a/apps/backend/src/reconciliation/cash-exceptions.service.ts
+++ b/apps/backend/src/reconciliation/cash-exceptions.service.ts
@@ -11,10 +11,12 @@ import { PaymentService } from '../transaction/payment.service';
 @Injectable()
 export class CashExceptionsService {
   constructor(
-    @Inject(Logger) private appLogger: AppLogger,
     @Inject(CashDepositService) private cashDepositService: CashDepositService,
-    @Inject(PaymentService) private paymentService: PaymentService
-  ) {}
+    @Inject(PaymentService) private paymentService: PaymentService,
+    private appLogger: AppLogger
+  ) {
+    this.appLogger.setContext(`CashExceptionsService`);
+  }
   /**
    *
    * @param event

--- a/apps/backend/src/reconciliation/pos-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/pos-reconciliation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { differenceInMinutes } from 'date-fns';
 import { ReconciliationType } from './types';
 import { MatchStatus } from '../common/const';
@@ -13,10 +13,12 @@ import { PaymentService } from '../transaction/payment.service';
 @Injectable()
 export class POSReconciliationService {
   constructor(
-    @Inject(Logger) private readonly appLogger: AppLogger,
     @Inject(PosDepositService) private posDepositService: PosDepositService,
-    @Inject(PaymentService) private paymentService: PaymentService
-  ) {}
+    @Inject(PaymentService) private paymentService: PaymentService,
+    private readonly appLogger: AppLogger
+  ) {
+    this.appLogger.setContext(`POSReconciliationService`);
+  }
 
   // TODO [CCFPCM-406] move the save as matched separately..
   // TODO [CCFPCM-406] implement as layer
@@ -160,15 +162,9 @@ export class POSReconciliationService {
       };
     }
 
-    this.appLogger.log(
-      `pending payments ${pendingPayments.length}`,
-      POSReconciliationService.name
-    );
+    this.appLogger.log(`pending payments ${pendingPayments.length}`);
 
-    this.appLogger.log(
-      `pending deposits ${pendingDeposits.length}`,
-      POSReconciliationService.name
-    );
+    this.appLogger.log(`pending deposits ${pendingDeposits.length}`);
 
     const roundOneMatches: {
       payment: PaymentEntity;
@@ -179,10 +175,7 @@ export class POSReconciliationService {
       5
     );
 
-    this.appLogger.log(
-      `MATCHES - ROUND ONE ${roundOneMatches.length}`,
-      POSReconciliationService.name
-    );
+    this.appLogger.log(`MATCHES - ROUND ONE ${roundOneMatches.length}`);
 
     const roundTwoMatches: {
       payment: PaymentEntity;
@@ -193,10 +186,7 @@ export class POSReconciliationService {
       1440
     );
 
-    this.appLogger.log(
-      `MATCHES - ROUND TWO ${roundTwoMatches.length}`,
-      POSReconciliationService.name
-    );
+    this.appLogger.log(`MATCHES - ROUND TWO ${roundTwoMatches.length}`);
 
     const paymentsMatched = await Promise.all(
       await this.paymentService.updatePayments(

--- a/apps/backend/src/reconciliation/reconciliation.module.ts
+++ b/apps/backend/src/reconciliation/reconciliation.module.ts
@@ -1,4 +1,5 @@
-import { Module, Logger } from '@nestjs/common';
+import { Module } from '@nestjs/common';
+import { AppLogger } from '../logger/logger.service';
 import { CashExceptionsService } from './cash-exceptions.service';
 import { CashReconciliationService } from './cash-reconciliation.service';
 import { POSReconciliationService } from './pos-reconciliation.service';
@@ -9,9 +10,9 @@ import { TransactionModule } from '../transaction/transaction.module';
 @Module({
   imports: [DepositModule, TransactionModule, LocationModule],
   providers: [
+    AppLogger,
     CashReconciliationService,
     POSReconciliationService,
-    Logger,
     CashExceptionsService,
   ],
   exports: [],

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -5,5 +5,5 @@
     "baseUrl": "./",
     "allowJs": true
   },
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "./env.js"]
+  "exclude": ["node_modules", "**/*.spec.ts", "./env.js", "./dist"]
 }


### PR DESCRIPTION
Note: this is pending review from devs if we like this logging style better / find it appropriate

Objective: 
- Logging to fully utilize the logging service that was already written up
- Logs to have a timestamp with timezone
- Ability to set context in the app logger to avoid having to specify it in every log message

Attaching screenshots for the difference in console

Before
<img width="1019" alt="Screenshot 2023-05-16 at 11 59 27 PM" src="https://github.com/bcgov/PaymentCommonComponent/assets/61991654/8347afc0-7256-49b8-bbb2-80b87e4a1900">

After
<img width="1057" alt="Screenshot 2023-05-16 at 11 56 43 PM" src="https://github.com/bcgov/PaymentCommonComponent/assets/61991654/90fea89c-2d53-41ba-93c0-0b00ce1e5fb6">
