### PR TITLE
[FIX]: report updates for heuristic 3 changes

### DIFF
--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -1,5 +1,5 @@
 {
-  "period": { "from": "2023-03-01", "to": "2023-05-01" },
+  "period": { "from": "2023-01-01", "to": "2023-03-31" },
   "program": "SBC",
   "location_ids": []
 }

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-04-15"
+    "to": "2023-03-31"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-03-31"
+    "to": "2023-04-15"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/src/reporting/reporting.service.ts
+++ b/apps/backend/src/reporting/reporting.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { format, getMonth, getYear, parse } from 'date-fns';
+import {
+  format,
+  getMonth,
+  getYear,
+  isSaturday,
+  isSunday,
+  parse,
+} from 'date-fns';
 import { Repository } from 'typeorm';
 import { CasReport } from './cas-report/cas-report';
 import {
@@ -57,6 +64,17 @@ export class ReportingService {
       `Generating Reconciliation Report For ${locations.length} locations`,
       ReportingService.name
     );
+
+    if (
+      isSaturday(parse(config.period.to, 'yyyy-MM-dd', new Date())) ||
+      isSunday(parse(config.period.to, 'yyyy-MM-dd', new Date()))
+    ) {
+      this.appLogger.log(
+        `Skipping Reconciliation Report generation for ${config.period.to} as it is a weekend`,
+        ReportingService.name
+      );
+      return;
+    }
 
     this.excelWorkbook.addWorkbookMetadata('Reconciliation Report');
     await this.generateDailySummary(config, locations);

--- a/apps/backend/src/transaction/payment.service.ts
+++ b/apps/backend/src/transaction/payment.service.ts
@@ -195,7 +195,7 @@ export class PaymentService {
 
   async findMatchedPosPayments(posDeposits: POSDepositEntity[]) {
     return await this.paymentRepo.find({
-      where: { pos_deposit_match: In(posDeposits) },
+      where: { pos_deposit_match: In(posDeposits.map((itm) => itm.id)) },
     });
   }
   async updatePayments(payments: PaymentEntity[]): Promise<PaymentEntity[]> {

--- a/apps/backend/src/transaction/payment.service.ts
+++ b/apps/backend/src/transaction/payment.service.ts
@@ -4,6 +4,7 @@ import { Raw, In, Repository, LessThanOrEqual, LessThan } from 'typeorm';
 import { PaymentEntity } from './entities';
 import { MatchStatus, MatchStatusAll } from '../common/const';
 import { DateRange, PaymentMethodClassification } from '../constants';
+import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 import { LocationEntity } from '../location/entities';
 import { AppLogger } from '../logger/logger.service';
 import { AggregatedPayment } from '../reconciliation/types/interface';
@@ -192,6 +193,11 @@ export class PaymentService {
     });
   }
 
+  async findMatchedPosPayments(posDeposits: POSDepositEntity[]) {
+    return await this.paymentRepo.find({
+      where: { pos_deposit_match: In(posDeposits) },
+    });
+  }
   async updatePayments(payments: PaymentEntity[]): Promise<PaymentEntity[]> {
     return await this.paymentRepo.save(payments);
   }


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective: 

- date on summary/details/cas report should show the "to_date" when generating a report
- reports should not generate on the weekend
- page2 (details report): 
    - pos should show only pos deposits for the "to_date"
    - payments should show only pos payments for the "to_date", except in the case of a match (a payment may show on a different date if it matches 1:1 with a pos deposit from the report date)

