### PR TITLE
[CHORE] reconciliation sub bus days (cash report summary page)

### DIFF
--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -1,5 +1,5 @@
 {
-  "period": { "from": "2023-01-01", "to": "2023-03-31" },
+  "period": { "from": "2023-01-01", "to": "2023-04-30" },
   "program": "SBC",
   "location_ids": []
 }

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-04-15"
+    "to": "2023-03-31"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-03-31"
+    "to": "2023-04-15"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-03-31"
+    "to": "2023-04-03"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/src/deposits/pos-deposit.service.ts
+++ b/apps/backend/src/deposits/pos-deposit.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { format } from 'date-fns';
-import { In, LessThan, Raw, Repository } from 'typeorm';
+import { In, LessThanOrEqual, Raw, Repository } from 'typeorm';
 import { POSDepositEntity } from './entities/pos-deposit.entity';
 import { MatchStatus, MatchStatusAll } from '../common/const';
 import { mapLimit } from '../common/promises';
@@ -86,7 +86,7 @@ export class PosDepositService {
     );
     return await this.posDepositRepo.find({
       where: {
-        transaction_date: LessThan(date),
+        transaction_date: LessThanOrEqual(date),
         status: MatchStatus.IN_PROGRESS,
         merchant_id: In(locations.map((itm) => itm.merchant_id)),
         metadata: { program },

--- a/apps/backend/src/reconciliation/pos-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/pos-reconciliation.service.ts
@@ -46,8 +46,8 @@ export class PosReconciliationService {
     date: Date
   ): Promise<unknown> {
     const dateRange = {
-      minDate: format(subBusinessDays(date, 2), 'yyyy-MM-dd'),
-      maxDate: format(subBusinessDays(date, 1), 'yyyy-MM-dd'),
+      minDate: format(subBusinessDays(date, 1), 'yyyy-MM-dd'),
+      maxDate: format(date, 'yyyy-MM-dd'),
     };
 
     this.appLogger.log(

--- a/apps/backend/src/transaction/payment.service.ts
+++ b/apps/backend/src/transaction/payment.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Raw, In, Repository, LessThanOrEqual, LessThan } from 'typeorm';
+import { Raw, In, Repository, LessThanOrEqual } from 'typeorm';
 import { PaymentEntity } from './entities';
 import { MatchStatus, MatchStatusAll } from '../common/const';
 import { DateRange, PaymentMethodClassification } from '../constants';
@@ -55,7 +55,7 @@ export class PaymentService {
     return await this.paymentRepo.find({
       where: {
         transaction: {
-          transaction_date: LessThan(date),
+          transaction_date: LessThanOrEqual(date),
           location_id: location.location_id,
         },
         status: MatchStatus.IN_PROGRESS,
@@ -72,6 +72,7 @@ export class PaymentService {
       },
     });
   }
+
   public aggregatePayments(payments: PaymentEntity[]): AggregatedPayment[] {
     const groupedPayments = payments.reduce(
       /*eslint-disable */


### PR DESCRIPTION
[CHORE](https://bcdevex.atlassian.net/browse/CHORE)

Objective: 

- small update to run the cash reconciliation one business day behind in order to be on the same schedule as POS.
