### PR TITLE
[CCFPCM-0524] floating point decimal type precision loss bug

### DIFF
--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -3,7 +3,7 @@
   "locations": [],
   "period": {
     "from": "2023-01-01",
-    "to": "2023-05-25"
+    "to": "2023-05-24"
   },
   "exceptions": {
     "send": false

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
     "class-validator": "0.14.0",
     "csvtojson": "2.0.10",
     "date-fns": "2.29.3",
+    "decimal.js": "10.4.3",
     "exceljs": "4.3.0",
     "express": "4.18.2",
     "nest-aws-sdk": "3.0.0",

--- a/apps/backend/src/common/transformers/numericColumnTransformer.ts
+++ b/apps/backend/src/common/transformers/numericColumnTransformer.ts
@@ -1,8 +1,0 @@
-export class ColumnNumericTransformer {
-  to(data: number): number {
-    return data;
-  }
-  from(data: string): number {
-    return parseFloat(data);
-  }
-}

--- a/apps/backend/src/constants.ts
+++ b/apps/backend/src/constants.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { MatchStatus } from './common/const';
 import { POSDepositEntity } from './deposits/entities/pos-deposit.entity';
 import { PosHeuristicRound } from './reconciliation/types';
@@ -42,7 +43,7 @@ export enum PaymentMethodClassification {
 }
 
 export interface AggregatedDeposit {
-  transaction_amt: number;
+  transaction_amt: Decimal;
   transaction_date: string;
   status: MatchStatus;
   heuristic_match_round?: PosHeuristicRound;
@@ -54,7 +55,7 @@ export interface AggregatedPosPayment {
   transaction: {
     transaction_date: string;
   };
-  amount: number;
+  amount: Decimal;
   status: MatchStatus;
   heuristic_match_round?: PosHeuristicRound;
   round_four_matches: POSDepositEntity[];

--- a/apps/backend/src/deposits/entities/cash-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/cash-deposit.entity.ts
@@ -7,7 +7,6 @@ import {
 } from 'typeorm';
 import { FileMetadata } from '../../common/columns/metadata';
 import { MatchStatus } from '../../common/const';
-import { ColumnNumericTransformer } from '../../common/transformers/numericColumnTransformer';
 import { FileTypes } from '../../constants';
 import { TDI17Details } from '../../flat-files';
 import { PaymentEntity } from '../../transaction/entities/payment.entity';
@@ -45,7 +44,6 @@ export class CashDepositEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   deposit_amt_curr: number;
 
@@ -56,7 +54,6 @@ export class CashDepositEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   exchange_adj_amt: number;
 
@@ -64,7 +61,6 @@ export class CashDepositEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   deposit_amt_cdn: number;
 

--- a/apps/backend/src/deposits/entities/pos-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/pos-deposit.entity.ts
@@ -10,7 +10,6 @@ import {
 } from 'typeorm';
 import { FileMetadata } from '../../common/columns';
 import { MatchStatus } from '../../common/const';
-import { ColumnNumericTransformer } from '../../common/transformers/numericColumnTransformer';
 import { FileTypes } from '../../constants';
 import { TDI34Details } from '../../flat-files';
 import { PosHeuristicRound } from '../../reconciliation/types/const';
@@ -40,7 +39,6 @@ export class POSDepositEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   transaction_amt: number;
 

--- a/apps/backend/src/lambdas/utils/parseGarms.ts
+++ b/apps/backend/src/lambdas/utils/parseGarms.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { parseFlatDateString } from '../../common/utils/format';
 import { Ministries } from '../../constants';
 import { TransactionEntity, PaymentEntity } from '../../transaction/entities';
@@ -112,10 +113,7 @@ const parseSBCGarmsPayments = (
       garmsPayment.currency !== 'CAD' ? garmsPayment.amount : undefined,
     amount:
       garmsPayment.currency !== 'CAD' && garmsPayment.exchange_rate
-        ? parseFloat(
-            (garmsPayment.amount * (garmsPayment.exchange_rate / 100)).toFixed(
-              2
-            )
-          )
-        : parseFloat(garmsPayment.amount?.toFixed(2)),
+        ? new Decimal(garmsPayment.amount).toNumber() *
+          (garmsPayment.exchange_rate / 100)
+        : garmsPayment.amount,
   });

--- a/apps/backend/src/reconciliation/cash-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/cash-reconciliation.service.ts
@@ -60,10 +60,8 @@ export class CashReconciliationService {
     deposit: CashDepositEntity
   ) {
     return (
-      Math.abs(
-        new Decimal(deposit.deposit_amt_cdn).toNumber() -
-          new Decimal(payment.amount).toNumber()
-      ) < 0.001
+      new Decimal(deposit.deposit_amt_cdn).toNumber() ===
+      new Decimal(payment.amount).toNumber()
     );
   }
 

--- a/apps/backend/src/reconciliation/types/interface.ts
+++ b/apps/backend/src/reconciliation/types/interface.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { MatchStatus } from '../../common/const';
 import {
   DateRange,
@@ -39,13 +40,13 @@ export interface ReconciliationError {
   error: string;
 }
 
-export interface AggregatedPayment {
+export interface AggregatedCashPayment {
   status: MatchStatus;
   fiscal_close_date: string;
   location_id: number;
-  amount: number;
-  classification: PaymentMethodClassification.CASH;
-  cash_deposit_match: CashDepositEntity;
+  amount: Decimal;
+  classification: PaymentMethodClassification;
+  cash_deposit_match?: CashDepositEntity;
   payments: PaymentEntity[];
 }
 

--- a/apps/backend/src/reporting/cas-report/cas-report.ts
+++ b/apps/backend/src/reporting/cas-report/cas-report.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { NormalizedLocation } from '../../constants';
 
 export class CasLocationReport {
@@ -29,7 +30,8 @@ export class CasReport extends CasLocationReport {
     location: NormalizedLocation;
   }) {
     super(data.location);
+    this.settlement_date = data.settlement_date;
     this.card_vendor = data?.payment_method as string;
-    Object.assign(this, data);
+    this.amount = data.amount;
   }
 }

--- a/apps/backend/src/reporting/cas-report/cas-report.ts
+++ b/apps/backend/src/reporting/cas-report/cas-report.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js';
 import { NormalizedLocation } from '../../constants';
 
 export class CasLocationReport {
@@ -30,8 +29,7 @@ export class CasReport extends CasLocationReport {
     location: NormalizedLocation;
   }) {
     super(data.location);
-    this.settlement_date = data.settlement_date;
+    Object.assign(this, data);
     this.card_vendor = data?.payment_method as string;
-    this.amount = data.amount;
   }
 }

--- a/apps/backend/src/reporting/cas-report/cas-report.ts
+++ b/apps/backend/src/reporting/cas-report/cas-report.ts
@@ -29,7 +29,7 @@ export class CasReport extends CasLocationReport {
     location: NormalizedLocation;
   }) {
     super(data.location);
-    Object.assign(this, data);
     this.card_vendor = data?.payment_method as string;
+    Object.assign(this, data);
   }
 }

--- a/apps/backend/src/reporting/detailed-report/cash-details-report.ts
+++ b/apps/backend/src/reporting/detailed-report/cash-details-report.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { DetailsReport } from './details-report';
 import { DateRange, NormalizedLocation } from '../../constants';
 import { CashDepositEntity } from '../../deposits/entities/cash-deposit.entity';
@@ -18,12 +19,13 @@ export class CashDepositDetailsReport extends DetailsReport {
     this.time = deposit.deposit_time ?? null;
     this.fiscal_date = deposit.deposit_date;
     this.payment_method = 'CASH/CHQ';
-    this.amount = deposit.deposit_amt_cdn;
+    this.amount = new Decimal(deposit.deposit_amt_cdn).toNumber();
     this.foreign_currency_amount =
       deposit.deposit_amt_curr !== deposit.deposit_amt_cdn
-        ? deposit.deposit_amt_curr
+        ? new Decimal(deposit.deposit_amt_curr).toNumber()
         : null;
     this.currency = deposit.currency ?? 'CAD';
-    this.exchange_rate = deposit.exchange_adj_amt ?? null;
+    this.exchange_rate =
+      new Decimal(deposit.exchange_adj_amt).toNumber() ?? null;
   }
 }

--- a/apps/backend/src/reporting/details-report.service.ts
+++ b/apps/backend/src/reporting/details-report.service.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { format, parse, subBusinessDays } from 'date-fns';
+import Decimal from 'decimal.js';
 import {
   CashDepositDetailsReport,
   POSDepositDetailsReport,
@@ -53,8 +54,8 @@ export class DetailedReportService {
 
     /*eslint-disable */
     const totalSum = payments.reduce(
-      (acc: number, itm: PaymentEntity) => (acc += itm.amount),
-      0
+      (acc: Decimal, itm: PaymentEntity) => acc.plus(itm.amount),
+      new Decimal(0)
     );
 
     return {
@@ -66,7 +67,7 @@ export class DetailedReportService {
         total_payments: total,
         total_unmatched_payments: exceptions,
         percent_unmatched: unmatchedPercentage,
-        total_sum: parseFloat(totalSum.toFixed(2)),
+        total_sum: parseFloat(`${totalSum}`),
       },
       style: rowStyle(exceptions !== 0),
     };

--- a/apps/backend/src/reporting/reporting.service.ts
+++ b/apps/backend/src/reporting/reporting.service.ts
@@ -8,6 +8,7 @@ import {
   isSunday,
   parse,
 } from 'date-fns';
+import Decimal from 'decimal.js';
 import { Repository } from 'typeorm';
 import { CasReport } from './cas-report/cas-report';
 import {
@@ -201,7 +202,7 @@ export class ReportingService {
             location,
             payment_method,
             settlement_date,
-            amount: parseFloat(transaction_amt.toString()),
+            amount: transaction_amt,
           })
       );
 
@@ -376,8 +377,8 @@ export class ReportingService {
 
     /*eslint-disable */
     const totalSum = payments.reduce(
-      (acc: number, itm: PaymentEntity) => (acc += itm.amount),
-      0
+      (acc: Decimal, itm: PaymentEntity) => acc.plus(itm.amount),
+      new Decimal(0)
     );
 
     return {
@@ -389,7 +390,7 @@ export class ReportingService {
         total_payments: total,
         total_unmatched_payments: exceptions,
         percent_unmatched: unmatchedPercentage,
-        total_sum: parseFloat(totalSum.toFixed(2)),
+        total_sum: new Decimal(totalSum).toDecimalPlaces(2).toNumber(),
       },
       style: rowStyle(exceptions !== 0),
     };

--- a/apps/backend/src/transaction/entities/payment.entity.ts
+++ b/apps/backend/src/transaction/entities/payment.entity.ts
@@ -13,7 +13,6 @@ import {
 import { PaymentMethodEntity } from './payment-method.entity';
 import { TransactionEntity } from './transaction.entity';
 import { MatchStatus } from '../../common/const';
-import { ColumnNumericTransformer } from '../../common/transformers/numericColumnTransformer';
 import { CashDepositEntity } from '../../deposits/entities/cash-deposit.entity';
 import { POSDepositEntity } from '../../deposits/entities/pos-deposit.entity';
 import { PosHeuristicRound } from '../../reconciliation/types';
@@ -31,7 +30,6 @@ export class PaymentEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   amount: number;
 
@@ -51,7 +49,6 @@ export class PaymentEntity {
     precision: 16,
     scale: 4,
     nullable: true,
-    transformer: new ColumnNumericTransformer(),
   })
   exchange_rate?: number;
 

--- a/apps/backend/src/transaction/entities/transaction.entity.ts
+++ b/apps/backend/src/transaction/entities/transaction.entity.ts
@@ -1,7 +1,6 @@
 import { Relation, OneToMany, Entity, Column, PrimaryColumn } from 'typeorm';
 import { PaymentEntity } from './payment.entity';
 import { Transaction } from '../interface/transaction.interface';
-import { ColumnNumericTransformer } from '../../common/transformers/numericColumnTransformer';
 
 @Entity('transaction')
 export class TransactionEntity {
@@ -21,7 +20,6 @@ export class TransactionEntity {
     type: 'numeric',
     precision: 16,
     scale: 2,
-    transformer: new ColumnNumericTransformer(),
   })
   total_transaction_amount: number;
 

--- a/apps/backend/test/mocks/mocks.cash.spec.ts
+++ b/apps/backend/test/mocks/mocks.cash.spec.ts
@@ -4,7 +4,7 @@ import { PaymentMock } from './classes/payment_mock';
 import { MockData } from './mocks';
 import { aggregatePayments } from '../unit/reconciliation/helpers';
 import { PaymentMethodClassification } from '../../src/constants';
-import { AggregatedPayment } from '../../src/reconciliation/types';
+import { AggregatedCashPayment } from '../../src/reconciliation/types';
 
 describe('Tests the generated mock data', () => {
   let cashDepositsMock: CashDepositMock[];
@@ -29,8 +29,8 @@ describe('Tests the generated mock data', () => {
         amount: itm.amount,
       })),
     };
-    expect(expected.payments.map((itm) => itm.amount)).toEqual(
-      expected.deposits.map((itm) => itm.amount)
+    expect(expected.payments.map((itm) => itm.amount.toString())).toEqual(
+      expected.deposits.map((itm) => itm.amount.toString())
     );
   });
 
@@ -39,7 +39,7 @@ describe('Tests the generated mock data', () => {
       parse(itm.deposit_date, 'yyyy-MM-dd', new Date())
     );
     const paymentsDates = aggregatePayments(cashPaymentsMock).map(
-      (itm: AggregatedPayment) =>
+      (itm: AggregatedCashPayment) =>
         parse(itm.fiscal_close_date, 'yyyy-MM-dd', new Date())
     );
     // compareAsc returns -1 if the first date is before the second date, which causes this function to fail

--- a/apps/backend/test/mocks/mocks.ts
+++ b/apps/backend/test/mocks/mocks.ts
@@ -14,7 +14,7 @@ import {
   NormalizedLocation,
 } from '../../src/constants';
 import { PaymentMethodClassification } from '../../src/constants';
-import { AggregatedPayment } from '../../src/reconciliation/types';
+import { AggregatedCashPayment } from '../../src/reconciliation/types';
 import { PaymentEntity } from '../../src/transaction/entities';
 
 export class MockData {
@@ -44,13 +44,13 @@ export class MockData {
   generateCashDeposits(payments: PaymentEntity[]): CashDepositMock[] {
     const aggregatedPayments = aggregatePayments(payments);
     const cashDeposits: CashDepositMock[] = [];
-    aggregatedPayments.forEach((payment: AggregatedPayment) => {
+    aggregatedPayments.forEach((payment: AggregatedCashPayment) => {
       cashDeposits.push(
         new CashDepositMock(
           this.dateRange,
           this.location,
           generateMetadataMock(FileTypes.TDI17),
-          payment.amount,
+          payment.amount.toNumber(),
           this.status
         )
       );

--- a/apps/backend/test/unit/reconciliation/pos-reconciliation.spec.ts
+++ b/apps/backend/test/unit/reconciliation/pos-reconciliation.spec.ts
@@ -467,12 +467,6 @@ describe('PosReconciliationService', () => {
       const reaggregatedDeposits = service.aggregateDeposits(
         roundFourDepositMatches
       );
-      console.log(
-        'PAYMENTS: ',
-        reaggregatedPayments,
-        'DEPOSITS: ',
-        reaggregatedDeposits
-      );
       expect(
         reaggregatedPayments.map((aggregatedPayment: AggregatedPosPayment) => ({
           amount: aggregatedPayment.amount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,6 +2419,7 @@ __metadata:
     class-validator: 0.14.0
     csvtojson: 2.0.10
     date-fns: 2.29.3
+    decimal.js: 10.4.3
     eslint: 8.32.0
     eslint-config-prettier: 8.6.0
     eslint-nibble: 8.1.0
@@ -5030,6 +5031,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:10.4.3":
+  version: 10.4.3
+  resolution: "decimal.js@npm:10.4.3"
+  checksum: 796404dcfa9d1dbfdc48870229d57f788b48c21c603c3f6554a1c17c10195fc1024de338b0cf9e1efe0c7c167eeb18f04548979bcc5fdfabebb7cc0ae3287bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[CCFPCM-0524](https://bcdevex.atlassian.net/browse/CCFPCM-0524)

Objective: 

- when aggregating payment and deposit sums we are losing .001 of a decimal in some cases, which is causing a false exception when matching for pos round four heuristics as well as cash payments to deposits
- implement decimal.js library to use the decimal type when summing the payment/deposit totals


