### PR TITLE
[CCFPCM-497] file ingestion

### DIFF
--- a/.config/.env.example
+++ b/.config/.env.example
@@ -37,3 +37,5 @@ BASTION_INSTANCE_ID_TEST=
 
 NODE_ENV=local
 RUNTIME_ENV=local
+
+API_URL=http://localhost:3000

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -14,4 +14,4 @@ sonar.tests=apps/backend/test
 sonar.sourceEncoding=UTF-8
 
 # Exclusions for copy-paste detection
-#sonar.cpd.exclusions=
+sonar.cpd.exclusions=apps/backend/src/database/migrations/*.ts

--- a/apps/backend/src/common/decorators/fixedWidthRecord.decorator.ts
+++ b/apps/backend/src/common/decorators/fixedWidthRecord.decorator.ts
@@ -61,7 +61,7 @@ export enum DataType {
   Decimal = 'Decimal',
   Boolean = 'Boolean',
   Float = 'Float',
-  Integer = 'Integer ',
+  Integer = 'Integer',
   Date = 'Date',
   Time = 'Time',
   Card = 'Card',

--- a/apps/backend/src/common/entities/FixedWidthRecord.ts
+++ b/apps/backend/src/common/entities/FixedWidthRecord.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO [CCFPCM-397] Can we type more here?
+import Decimal from 'decimal.js';
 import { Resource, ResourceBase } from './Resource';
 import {
   ColumnMetadataKey,
@@ -65,9 +66,9 @@ export class FixedWidthRecord<T extends IFixedWidthRecord<T>>
         if (options.format.type === DataType.Integer) {
           (target as any)[field] = parseInt(value);
         } else if (options.format.type === DataType.Float) {
-          (target as any)[field] = parseInt(value).toFixed(
-            options.format.precision || 2
-          );
+          (target as any)[field] = new Decimal(value)
+            .toDecimalPlaces(2)
+            .toNumber();
         } else if (options.format.type === DataType.Date) {
           (target as any)[field] = value ? parseFlatDateString(value) : null;
         } else if (options.format.type === DataType.Time) {

--- a/apps/backend/src/database/datasource.ts
+++ b/apps/backend/src/database/datasource.ts
@@ -3,14 +3,14 @@ import { dbLogger, logLevels } from './helpers';
 import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
 import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 import { LocationEntity } from '../location/entities';
-import { FileUploadedEntity } from '../parse/entities/file-uploaded.entity';
 import { FileIngestionRulesEntity } from '../parse/entities/file-ingestion-rules.entity';
+import { FileUploadedEntity } from '../parse/entities/file-uploaded.entity';
+import { ProgramDailyUploadEntity } from '../parse/entities/program-daily-upload.entity';
 import {
   TransactionEntity,
   PaymentEntity,
   PaymentMethodEntity,
 } from '../transaction/entities/index';
-import { ProgramDailyUploadEntity } from '../parse/entities/program-daily-upload.entity';
 
 export default new DataSource({
   type: 'postgres',

--- a/apps/backend/src/database/datasource.ts
+++ b/apps/backend/src/database/datasource.ts
@@ -3,11 +3,14 @@ import { dbLogger, logLevels } from './helpers';
 import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
 import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 import { LocationEntity } from '../location/entities';
+import { FileUploadedEntity } from '../parse/entities/file-uploaded.entity';
+import { FileIngestionRulesEntity } from '../parse/entities/file-ingestion-rules.entity';
 import {
   TransactionEntity,
   PaymentEntity,
   PaymentMethodEntity,
 } from '../transaction/entities/index';
+import { ProgramDailyUploadEntity } from '../parse/entities/program-daily-upload.entity';
 
 export default new DataSource({
   type: 'postgres',
@@ -23,6 +26,9 @@ export default new DataSource({
     POSDepositEntity,
     CashDepositEntity,
     LocationEntity,
+    FileUploadedEntity,
+    ProgramDailyUploadEntity,
+    FileIngestionRulesEntity,
   ],
   migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
   synchronize: false,

--- a/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
+++ b/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
@@ -14,15 +14,6 @@ export class migration1686030966770 implements MigrationInterface {
       `CREATE TABLE "file_uploaded" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "source_file_type" character varying NOT NULL DEFAULT 'TDI17', "source_file_name" character varying NOT NULL, "source_file_length" integer NOT NULL, "daily_upload_id" uuid, CONSTRAINT "PK_27908e2def3d89bd889a9cd65dd" PRIMARY KEY ("id"))`
     );
     await queryRunner.query(
-      `CREATE TABLE "payment_round_four_matches_pos_deposit" ("paymentId" uuid NOT NULL, "posDepositId" uuid NOT NULL, CONSTRAINT "PK_d099fc3b96ce39951bae36f4991" PRIMARY KEY ("paymentId", "posDepositId"))`
-    );
-    await queryRunner.query(
-      `CREATE INDEX "IDX_f06ddb89870cda098fcd4dcb82" ON "payment_round_four_matches_pos_deposit" ("paymentId") `
-    );
-    await queryRunner.query(
-      `CREATE INDEX "IDX_70d2cd6ca48dc18df656f23cb5" ON "payment_round_four_matches_pos_deposit" ("posDepositId") `
-    );
-    await queryRunner.query(
       `ALTER TABLE "transaction" ADD "file_uploaded" uuid`
     );
     await queryRunner.query(
@@ -46,21 +37,9 @@ export class migration1686030966770 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "cash_deposit" ADD CONSTRAINT "FK_6da8fc3556db7ef6fe1c9444fb8" FOREIGN KEY ("file_uploaded") REFERENCES "file_uploaded"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
     );
-    await queryRunner.query(
-      `ALTER TABLE "payment_round_four_matches_pos_deposit" ADD CONSTRAINT "FK_f06ddb89870cda098fcd4dcb822" FOREIGN KEY ("paymentId") REFERENCES "payment"("id") ON DELETE CASCADE ON UPDATE CASCADE`
-    );
-    await queryRunner.query(
-      `ALTER TABLE "payment_round_four_matches_pos_deposit" ADD CONSTRAINT "FK_70d2cd6ca48dc18df656f23cb56" FOREIGN KEY ("posDepositId") REFERENCES "pos_deposit"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
-    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "payment_round_four_matches_pos_deposit" DROP CONSTRAINT "FK_70d2cd6ca48dc18df656f23cb56"`
-    );
-    await queryRunner.query(
-      `ALTER TABLE "payment_round_four_matches_pos_deposit" DROP CONSTRAINT "FK_f06ddb89870cda098fcd4dcb822"`
-    );
     await queryRunner.query(
       `ALTER TABLE "cash_deposit" DROP CONSTRAINT "FK_6da8fc3556db7ef6fe1c9444fb8"`
     );
@@ -90,9 +69,6 @@ export class migration1686030966770 implements MigrationInterface {
     );
     await queryRunner.query(
       `DROP INDEX "public"."IDX_f06ddb89870cda098fcd4dcb82"`
-    );
-    await queryRunner.query(
-      `DROP TABLE "payment_round_four_matches_pos_deposit"`
     );
     await queryRunner.query(`DROP TABLE "file_uploaded"`);
     await queryRunner.query(`DROP TABLE "program_daily_upload"`);

--- a/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
+++ b/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
@@ -1,0 +1,71 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1686030966770 implements MigrationInterface {
+  name = 'file-ingestion-migration1686030966770';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "file_ingestion_rules" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "program" character varying NOT NULL, "cashChequesFilename" character varying NOT NULL, "cardsFilename" character varying NOT NULL, "transactionsFilename" character varying NOT NULL, "retries" integer NOT NULL DEFAULT '0', CONSTRAINT "PK_092531b74dee2a92a21d2e1d981" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "program_daily_upload" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "dataDate" date NOT NULL, "success" boolean NOT NULL, "retries" integer NOT NULL, "ruleId" uuid, CONSTRAINT "PK_24196c3558e5e3bf7617a2b453d" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "file_uploaded" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "source_file_type" character varying NOT NULL DEFAULT 'TDI17', "source_file_name" character varying NOT NULL, "source_file_length" integer NOT NULL, "programFilesId" uuid, CONSTRAINT "PK_27908e2def3d89bd889a9cd65dd" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ADD "file_uploaded" uuid`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pos_deposit" ADD "file_uploaded" uuid`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" ADD "file_uploaded" uuid`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "program_daily_upload" ADD CONSTRAINT "FK_9f44128650393d73bccc114765b" FOREIGN KEY ("ruleId") REFERENCES "file_ingestion_rules"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_uploaded" ADD CONSTRAINT "FK_0aff59d03597f87030b84c868d2" FOREIGN KEY ("programFilesId") REFERENCES "program_daily_upload"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transaction" ADD CONSTRAINT "FK_c90546b2c82635228ccfe411a54" FOREIGN KEY ("file_uploaded") REFERENCES "file_uploaded"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pos_deposit" ADD CONSTRAINT "FK_17acb8fdfe49332f44ad809be98" FOREIGN KEY ("file_uploaded") REFERENCES "file_uploaded"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" ADD CONSTRAINT "FK_6da8fc3556db7ef6fe1c9444fb8" FOREIGN KEY ("file_uploaded") REFERENCES "file_uploaded"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" DROP CONSTRAINT "FK_6da8fc3556db7ef6fe1c9444fb8"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pos_deposit" DROP CONSTRAINT "FK_17acb8fdfe49332f44ad809be98"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transaction" DROP CONSTRAINT "FK_c90546b2c82635228ccfe411a54"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_uploaded" DROP CONSTRAINT "FK_0aff59d03597f87030b84c868d2"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "program_daily_upload" DROP CONSTRAINT "FK_9f44128650393d73bccc114765b"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cash_deposit" DROP COLUMN "file_uploaded"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pos_deposit" DROP COLUMN "file_uploaded"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "transaction" DROP COLUMN "file_uploaded"`
+    );
+    await queryRunner.query(`DROP TABLE "file_uploaded"`);
+    await queryRunner.query(`DROP TABLE "program_daily_upload"`);
+    await queryRunner.query(`DROP TABLE "file_ingestion_rules"`);
+  }
+}

--- a/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
+++ b/apps/backend/src/database/migrations/1686030966770-file-ingestion-migration.ts
@@ -11,7 +11,7 @@ export class migration1686030966770 implements MigrationInterface {
       `CREATE TABLE "program_daily_upload" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "daily_date" date NOT NULL, "success" boolean NOT NULL, "retries" integer NOT NULL, "ruleId" uuid, CONSTRAINT "PK_24196c3558e5e3bf7617a2b453d" PRIMARY KEY ("id"))`
     );
     await queryRunner.query(
-      `CREATE TABLE "file_uploaded" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "source_file_type" character varying NOT NULL DEFAULT 'TDI17', "source_file_name" character varying NOT NULL, "source_file_length" integer NOT NULL, "daily_upload_id" uuid, CONSTRAINT "PK_27908e2def3d89bd889a9cd65dd" PRIMARY KEY ("id"))`
+      `CREATE TABLE "file_uploaded" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "source_file_type" character varying NOT NULL, "source_file_name" character varying NOT NULL, "source_file_length" integer NOT NULL, "daily_upload_id" uuid, CONSTRAINT "PK_27908e2def3d89bd889a9cd65dd" PRIMARY KEY ("id"))`
     );
     await queryRunner.query(
       `ALTER TABLE "transaction" ADD "file_uploaded" uuid`

--- a/apps/backend/src/database/migrations/1686207492088-filenames-rules-migration.ts
+++ b/apps/backend/src/database/migrations/1686207492088-filenames-rules-migration.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1686207492088 implements MigrationInterface {
+  name = 'filenames-rules-migration1686207492088';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO file_ingestion_rules(program, cash_cheques_filename, pos_filename, transactions_filename, retries) VALUES ('SBC', 'F08TDI17', 'F08TDI34', 'SBC_SALES', 2)`
+    );
+
+    await queryRunner.query(
+      `INSERT INTO file_ingestion_rules(program, cash_cheques_filename, pos_filename, transactions_filename, retries) VALUES ('LABOUR', 'F08TDI17', 'F08TDI34', null, 2)`
+    );
+
+    await queryRunner.query(
+      `INSERT INTO file_uploaded ("source_file_type", "source_file_name", "source_file_length") SELECT 'SBC_SALES' as source_file_type, source_file_name, count(*) as source_file_length FROM transaction WHERE file_uploaded IS NULL GROUP BY source_file_name`
+    );
+
+    await queryRunner.query(
+      `INSERT INTO file_uploaded ("source_file_type", "source_file_name", "source_file_length") SELECT 'TDI17' as source_file_type, source_file_name, source_file_length FROM cash_deposit WHERE file_uploaded IS NULL GROUP BY source_file_name, source_file_length`
+    );
+
+    await queryRunner.query(
+      `INSERT INTO file_uploaded ("source_file_type", "source_file_name", "source_file_length") SELECT 'TDI34' as source_file_type, source_file_name, source_file_length FROM pos_deposit WHERE file_uploaded IS NULL GROUP BY source_file_name, source_file_length`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM file_uploaded WHERE daily_upload_id IS NULL`
+    );
+
+    await queryRunner.query(
+      `DELETE FROM file_ingestion_rules WHERE program IN ('SBC', 'LABOUR')`
+    );
+  }
+}

--- a/apps/backend/src/deposits/entities/cash-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/cash-deposit.entity.ts
@@ -7,11 +7,11 @@ import {
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { FileMetadata } from '../../common/columns/metadata';
 import { MatchStatus } from '../../common/const';
 import { FileTypes } from '../../constants';
 import { TDI17Details } from '../../flat-files';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { PaymentEntity } from '../../transaction/entities/payment.entity';
 
 @Entity('cash_deposit')

--- a/apps/backend/src/deposits/entities/cash-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/cash-deposit.entity.ts
@@ -1,10 +1,13 @@
 import {
   Relation,
+  ManyToOne,
   OneToMany,
   Column,
+  JoinColumn,
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { FileMetadata } from '../../common/columns/metadata';
 import { MatchStatus } from '../../common/const';
 import { FileTypes } from '../../constants';
@@ -83,6 +86,10 @@ export class CashDepositEntity {
     nullable: true,
   })
   payment_match?: Relation<PaymentEntity[]>;
+
+  @ManyToOne(() => FileUploadedEntity, { nullable: true })
+  @JoinColumn({ name: 'file_uploaded' })
+  fileUploadedEntity?: FileUploadedEntity;
 
   constructor(data?: TDI17Details) {
     Object.assign(this, data?.resource);

--- a/apps/backend/src/deposits/entities/pos-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/pos-deposit.entity.ts
@@ -8,11 +8,11 @@ import {
   PrimaryGeneratedColumn,
   Relation,
 } from 'typeorm';
-import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { FileMetadata } from '../../common/columns';
 import { MatchStatus } from '../../common/const';
 import { FileTypes } from '../../constants';
 import { TDI34Details } from '../../flat-files';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { PosHeuristicRound } from '../../reconciliation/types/const';
 import { PaymentEntity, PaymentMethodEntity } from '../../transaction/entities';
 

--- a/apps/backend/src/deposits/entities/pos-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/pos-deposit.entity.ts
@@ -8,6 +8,7 @@ import {
   PrimaryGeneratedColumn,
   Relation,
 } from 'typeorm';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { FileMetadata } from '../../common/columns';
 import { MatchStatus } from '../../common/const';
 import { FileTypes } from '../../constants';
@@ -71,6 +72,10 @@ export class POSDepositEntity {
     nullable: true,
   })
   round_four_matches?: Relation<PaymentEntity[]>;
+
+  @ManyToOne(() => FileUploadedEntity, { nullable: true })
+  @JoinColumn({ name: 'file_uploaded' })
+  fileUploadedEntity?: FileUploadedEntity;
 
   constructor(data?: TDI34Details) {
     Object.assign(this, data?.resource);

--- a/apps/backend/src/flat-files/tdi17/TDI17Details.ts
+++ b/apps/backend/src/flat-files/tdi17/TDI17Details.ts
@@ -90,7 +90,7 @@ export class TDI17Details
     this.resource.pt_location_id = data;
   }
 
-  @Column({ start: 15, width: 5 })
+  @Column({ start: 15, width: 5, format: { type: DataType.Integer } })
   public get pt_location_id(): number {
     return this.resource.pt_location_id;
   }
@@ -133,7 +133,7 @@ export class TDI17Details
     this.resource.negative_indicator_curr = data;
   }
 
-  @Column({ start: 67, width: 12, format: { type: DataType.Decimal } })
+  @Column({ start: 67, width: 12, format: { type: DataType.Float } })
   public get deposit_amt_curr() {
     return this.resource.deposit_amt_curr;
   }
@@ -165,7 +165,7 @@ export class TDI17Details
   @Column({
     start: 82,
     width: 12,
-    format: { type: DataType.Decimal },
+    format: { type: DataType.Float },
   })
   public get exchange_adj_amt() {
     return this.resource.exchange_adj_amt;
@@ -187,7 +187,7 @@ export class TDI17Details
     this.resource.negative_indicator_cdn = data;
   }
 
-  @Column({ start: 95, width: 12, format: { type: DataType.Decimal } })
+  @Column({ start: 95, width: 12, format: { type: DataType.Float } })
   public get deposit_amt_cdn() {
     return this.resource.deposit_amt_cdn;
   }

--- a/apps/backend/src/flat-files/tdi34/TDI34Details.ts
+++ b/apps/backend/src/flat-files/tdi34/TDI34Details.ts
@@ -171,7 +171,7 @@ export class TDI34Details
     this.resource.fill3 = data;
   }
 
-  @Column({ start: 80, width: 9, format: { type: DataType.Decimal } })
+  @Column({ start: 80, width: 9, format: { type: DataType.Float } })
   public get transaction_amt(): number {
     return this.resource.transaction_amt;
   }

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -1,6 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { Context } from 'aws-lambda';
 import * as _ from 'underscore';
+import { isSaturday, isSunday, parse } from 'date-fns';
+
 import { getLambdaEventSource } from './utils/eventTypes';
 import { parseGarms } from './utils/parseGarms';
 import { parseTDI } from './utils/parseTDI';
@@ -36,6 +38,14 @@ const API_URL = 'http://localhost:3000/api';
 export const handler = async (event?: unknown, _context?: Context) => {
   const app = await NestFactory.createApplicationContext(AppModule);
   const appLogger = app.get(AppLogger);
+
+  if (isSaturday(new Date()) || isSunday(new Date())) {
+    appLogger.log(
+      `Skipping Reconciliation Report generation for ${new Date()} as it is a weekend`
+    );
+    return;
+  }
+
   const parseService = app.get(ParseService);
   const transactionService = app.get(TransactionService);
   const paymentMethodService = app.get(PaymentMethodService);

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -174,10 +174,8 @@ export const handler = async (event?: unknown, _context?: Context) => {
             currentRule = rule;
             return rule.program;
           }
-          throw new Error(
-            'File does not reference to any programs: ' + filename
-          );
         }
+        throw new Error(`File does not reference to any programs: ${filename}`);
       })();
 
       if (!currentRule) {

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -192,8 +192,8 @@ export const handler = async (event?: unknown, _context?: Context) => {
           return FileTypes.TDI17;
         }
         if (
-          currentRule.cardsFilename &&
-          filename.includes(currentRule.cardsFilename)
+          currentRule.posFilename &&
+          filename.includes(currentRule.posFilename)
         ) {
           return FileTypes.TDI34;
         }

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -48,12 +48,10 @@ export const handler = async (event?: unknown, _context?: Context) => {
 
   const parseService = app.get(ParseService);
   const transactionService = app.get(TransactionService);
-  const paymentMethodService = app.get(PaymentMethodService);
   const s3 = app.get(S3ManagerService);
   const posService = app.get(PosDepositService);
   const cashService = app.get(CashDepositService);
 
-  const paymentMethods = await paymentMethodService.getPaymentMethods();
   const processAllFiles = async () => {
     appLogger.log('Processing all files...');
     try {

--- a/apps/backend/src/lambdas/utils/parseGarms.ts
+++ b/apps/backend/src/lambdas/utils/parseGarms.ts
@@ -113,7 +113,9 @@ const parseSBCGarmsPayments = (
       garmsPayment.currency !== 'CAD' ? garmsPayment.amount : undefined,
     amount:
       garmsPayment.currency !== 'CAD' && garmsPayment.exchange_rate
-        ? new Decimal(garmsPayment.amount).toNumber() *
-          (garmsPayment.exchange_rate / 100)
+        ? new Decimal(garmsPayment.amount)
+            .times(garmsPayment.exchange_rate / 100)
+            .toDecimalPlaces(2)
+            .toNumber()
         : garmsPayment.amount,
   });

--- a/apps/backend/src/lambdas/utils/parseGarms.ts
+++ b/apps/backend/src/lambdas/utils/parseGarms.ts
@@ -114,7 +114,11 @@ const parseSBCGarmsPayments = (
     amount:
       garmsPayment.currency !== 'CAD' && garmsPayment.exchange_rate
         ? new Decimal(garmsPayment.amount)
-            .times(garmsPayment.exchange_rate / 100)
+            .times(
+              new Decimal(garmsPayment.exchange_rate / 100)
+                .toDecimalPlaces(2) // TODO: We will need to check this, as it might cause imprecision
+                .toNumber()
+            )
             .toDecimalPlaces(2)
             .toNumber()
         : garmsPayment.amount,

--- a/apps/backend/src/parse/dto/cash-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/cash-deposit.dto.ts
@@ -13,7 +13,7 @@ import { CashDepositEntity } from '../../deposits/entities/cash-deposit.entity';
 export class CashDepositDTO {
   //source file type
 
-  @ApiProperty({ description: 'Program Code', example: '0070' })
+  @ApiProperty({ description: 'Program Code', example: '0090' })
   @IsString()
   @IsOptional()
   program_code?: string;
@@ -23,7 +23,7 @@ export class CashDepositDTO {
   @IsNotEmpty()
   deposit_date!: string;
 
-  @ApiProperty({ description: 'Pt Location Id', example: '20094' })
+  @ApiProperty({ description: 'Pt Location Id', example: '29999' })
   @IsNumber()
   @IsNotEmpty()
   pt_location_id!: number;
@@ -61,7 +61,7 @@ export class CashDepositDTO {
   @IsNotEmpty()
   deposit_amt_cdn!: number;
 
-  @ApiProperty({ description: 'Destination Bank Number', example: '0010' })
+  @ApiProperty({ description: 'Destination Bank Number', example: '0090' })
   @IsNumberString()
   @IsNotEmpty()
   destination_bank_no!: string;

--- a/apps/backend/src/parse/dto/cash-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/cash-deposit.dto.ts
@@ -30,8 +30,8 @@ export class CashDepositDTO {
 
   @ApiProperty({ description: 'Deposit time', example: '162600' })
   @IsNumberString()
-  @IsNotEmpty()
-  deposit_time!: string;
+  @IsOptional()
+  deposit_time?: string;
 
   @ApiProperty({ description: 'Sequence Number', example: '001' })
   @IsNumberString()

--- a/apps/backend/src/parse/dto/cash-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/cash-deposit.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  IsNotEmpty,
+  IsDateString,
+  IsNumberString,
+  ValidateNested,
+} from 'class-validator';
+import { CashDepositEntity } from '../../deposits/entities/cash-deposit.entity';
+
+export class CashDepositDTO {
+  //source file type
+
+  @ApiProperty({ description: 'Program Code', example: '0070' })
+  @IsString()
+  @IsOptional()
+  program_code?: string;
+
+  @ApiProperty({ description: 'Deposit date', example: '2023-01-01' })
+  @IsDateString()
+  @IsNotEmpty()
+  deposit_date!: string;
+
+  @ApiProperty({ description: 'Pt Location Id', example: '20094' })
+  @IsNumberString()
+  @IsNotEmpty()
+  pt_location_id!: string;
+
+  @ApiProperty({ description: 'Deposit time', example: '162600' })
+  @IsNumberString()
+  @IsNotEmpty()
+  deposit_time!: string;
+
+  @ApiProperty({ description: 'Seuence Number', example: '001' })
+  @IsNumberString()
+  @IsNotEmpty()
+  seq_no!: string;
+
+  @ApiProperty({
+    description: 'Location Description',
+    example: 'SERVICE BC VICTORIA',
+  })
+  @IsString()
+  @IsNotEmpty()
+  location_desc!: string;
+
+  @ApiProperty({ description: 'Deposit amount curr', example: '100.00' })
+  @IsNumberString()
+  @IsNotEmpty()
+  deposit_amt_curr!: string;
+
+  @ApiProperty({ description: 'Exchange Adjusted Amount', example: '0.00' })
+  @IsNumberString()
+  @IsNotEmpty()
+  exchange_adj_amt!: string;
+
+  @ApiProperty({ description: 'Deposit amount Canadian', example: '100.00' })
+  @IsNumberString()
+  @IsNotEmpty()
+  deposit_amt_cdn!: string;
+
+  @ApiProperty({ description: 'Destination Bank Number', example: '0010' })
+  @IsNumberString()
+  @IsNotEmpty()
+  destination_bank_no!: string;
+
+  constructor(cashDeposit?: Partial<CashDepositEntity>) {
+    Object.assign(this, cashDeposit);
+  }
+}
+
+export class CashDepositsListDTO {
+  @ValidateNested({ each: true })
+  list: CashDepositDTO[];
+
+  constructor(cashDeposits: CashDepositDTO[]) {
+    this.list = cashDeposits;
+  }
+}

--- a/apps/backend/src/parse/dto/cash-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/cash-deposit.dto.ts
@@ -4,6 +4,7 @@ import {
   IsString,
   IsNotEmpty,
   IsDateString,
+  IsNumber,
   IsNumberString,
   ValidateNested,
 } from 'class-validator';
@@ -23,9 +24,9 @@ export class CashDepositDTO {
   deposit_date!: string;
 
   @ApiProperty({ description: 'Pt Location Id', example: '20094' })
-  @IsNumberString()
+  @IsNumber()
   @IsNotEmpty()
-  pt_location_id!: string;
+  pt_location_id!: number;
 
   @ApiProperty({ description: 'Deposit time', example: '162600' })
   @IsNumberString()
@@ -46,19 +47,19 @@ export class CashDepositDTO {
   location_desc!: string;
 
   @ApiProperty({ description: 'Deposit amount curr', example: '100.00' })
-  @IsNumberString()
+  @IsNumber()
   @IsNotEmpty()
-  deposit_amt_curr!: string;
+  deposit_amt_curr!: number;
 
   @ApiProperty({ description: 'Exchange Adjusted Amount', example: '0.00' })
-  @IsNumberString()
+  @IsNumber()
   @IsNotEmpty()
-  exchange_adj_amt!: string;
+  exchange_adj_amt!: number;
 
   @ApiProperty({ description: 'Deposit amount Canadian', example: '100.00' })
-  @IsNumberString()
+  @IsNumber()
   @IsNotEmpty()
-  deposit_amt_cdn!: string;
+  deposit_amt_cdn!: number;
 
   @ApiProperty({ description: 'Destination Bank Number', example: '0010' })
   @IsNumberString()

--- a/apps/backend/src/parse/dto/cash-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/cash-deposit.dto.ts
@@ -32,7 +32,7 @@ export class CashDepositDTO {
   @IsNotEmpty()
   deposit_time!: string;
 
-  @ApiProperty({ description: 'Seuence Number', example: '001' })
+  @ApiProperty({ description: 'Sequence Number', example: '001' })
   @IsNumberString()
   @IsNotEmpty()
   seq_no!: string;

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -23,9 +23,9 @@ export class GarmsPaymentDTO {
   @IsOptional()
   exchange_rate?: number;
 
-  @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
+  @ApiProperty({ description: 'Payment Method', example: '02' })
   @IsNotEmpty()
-  payment_method!: PaymentMethodEntity;
+  payment_method!: string;
 
   constructor(payment?: Partial<PaymentEntity>) {
     Object.assign(this, payment);

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -1,17 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, IsNotEmpty, IsNumber } from 'class-validator';
 import { PaymentEntity, PaymentMethodEntity } from '../../transaction/entities';
-import { PaymentChannel } from '../../transaction/interface/transaction.interface';
 
 export class GarmsPaymentDTO {
   @ApiProperty({ description: 'Amount paid in CAD', example: 134.5 })
-  @ApiProperty()
   @IsNumber()
   @IsNotEmpty()
   amount!: number;
 
   @ApiProperty({ description: 'Foreign currency amount', example: 100.0 })
-  @ApiProperty()
   @IsNumber()
   @IsOptional()
   foreign_currency_amount?: number;

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -23,9 +23,9 @@ export class GarmsPaymentDTO {
   @IsOptional()
   exchange_rate?: number;
 
-  @ApiProperty({ description: 'Payment Method', example: '02' })
+  @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
   @IsNotEmpty()
-  payment_method!: string;
+  payment_method!: PaymentMethodEntity;
 
   constructor(payment?: Partial<PaymentEntity>) {
     Object.assign(this, payment);

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -20,8 +20,8 @@ export class GarmsPaymentDTO {
 
   @ApiProperty({ description: 'Exchange Rate', example: 1.345 })
   @IsNumber()
-  @IsNotEmpty()
-  exchange_rate!: number;
+  @IsOptional()
+  exchange_rate?: number;
 
   @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
   @IsNotEmpty()

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -26,45 +26,6 @@ export class GarmsPaymentDTO {
   @IsNotEmpty()
   exchange_rate!: number;
 
-  @ApiProperty({
-    description: 'Channel',
-    example: 'in-person',
-    enum: PaymentChannel,
-  })
-  @IsString()
-  @IsNotEmpty()
-  channel!: string;
-
-  @ApiProperty({ description: 'Card Number', example: '1234' })
-  @IsString()
-  @IsNotEmpty()
-  card_no!: string;
-
-  @ApiProperty({ description: 'Merchant ID', example: 'ABCD1234' })
-  @IsString()
-  @IsNotEmpty()
-  merchant_id!: string;
-
-  @ApiProperty({ description: 'Device ID', example: 'ABCD1234' })
-  @IsString()
-  @IsNotEmpty()
-  device_id!: string;
-
-  @ApiProperty({ description: 'Invoice Number', example: 'ABCD1234' })
-  @IsString()
-  @IsNotEmpty()
-  invoice_no!: string;
-
-  @ApiProperty({ description: 'Transaction ID', example: 'ABCD1234' })
-  @IsString()
-  @IsNotEmpty()
-  tran_id!: string;
-
-  @ApiProperty({ description: 'Order Number', example: 'ABCD1234' })
-  @IsString()
-  @IsNotEmpty()
-  order_no!: string;
-
   @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
   @IsNotEmpty()
   payment_method!: PaymentMethodEntity;

--- a/apps/backend/src/parse/dto/garms-payment.dto.ts
+++ b/apps/backend/src/parse/dto/garms-payment.dto.ts
@@ -1,0 +1,75 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsNotEmpty, IsNumber } from 'class-validator';
+import { PaymentEntity, PaymentMethodEntity } from '../../transaction/entities';
+import { PaymentChannel } from '../../transaction/interface/transaction.interface';
+
+export class GarmsPaymentDTO {
+  @ApiProperty({ description: 'Amount paid in CAD', example: 134.5 })
+  @ApiProperty()
+  @IsNumber()
+  @IsNotEmpty()
+  amount!: number;
+
+  @ApiProperty({ description: 'Foreign currency amount', example: 100.0 })
+  @ApiProperty()
+  @IsNumber()
+  @IsOptional()
+  foreign_currency_amount?: number;
+
+  @ApiProperty({ description: 'Currency of payment', example: 'CAD' })
+  @IsString()
+  @IsNotEmpty()
+  currency!: string;
+
+  @ApiProperty({ description: 'Exchange Rate', example: 1.345 })
+  @IsNumber()
+  @IsNotEmpty()
+  exchange_rate!: number;
+
+  @ApiProperty({
+    description: 'Channel',
+    example: 'in-person',
+    enum: PaymentChannel,
+  })
+  @IsString()
+  @IsNotEmpty()
+  channel!: string;
+
+  @ApiProperty({ description: 'Card Number', example: '1234' })
+  @IsString()
+  @IsNotEmpty()
+  card_no!: string;
+
+  @ApiProperty({ description: 'Merchant ID', example: 'ABCD1234' })
+  @IsString()
+  @IsNotEmpty()
+  merchant_id!: string;
+
+  @ApiProperty({ description: 'Device ID', example: 'ABCD1234' })
+  @IsString()
+  @IsNotEmpty()
+  device_id!: string;
+
+  @ApiProperty({ description: 'Invoice Number', example: 'ABCD1234' })
+  @IsString()
+  @IsNotEmpty()
+  invoice_no!: string;
+
+  @ApiProperty({ description: 'Transaction ID', example: 'ABCD1234' })
+  @IsString()
+  @IsNotEmpty()
+  tran_id!: string;
+
+  @ApiProperty({ description: 'Order Number', example: 'ABCD1234' })
+  @IsString()
+  @IsNotEmpty()
+  order_no!: string;
+
+  @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
+  @IsNotEmpty()
+  payment_method!: PaymentMethodEntity;
+
+  constructor(payment?: Partial<PaymentEntity>) {
+    Object.assign(this, payment);
+  }
+}

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -66,7 +66,7 @@ export class GarmsTransactionDTO {
   source_id!: string;
 
   @ApiProperty({ description: 'Location ID', example: '47' })
-  @IsString()
+  @IsNumber()
   @IsNotEmpty()
   location_id!: string;
 

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -66,7 +66,7 @@ export class GarmsTransactionDTO {
   @IsNotEmpty()
   source_id!: string;
 
-  @ApiProperty({ description: 'Location ID', example: '47' })
+  @ApiProperty({ description: 'Location ID', example: '99' })
   @IsNumber()
   @IsNotEmpty()
   location_id!: number;

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -18,6 +18,10 @@ import { GarmsPaymentDTO } from './garms-payment.dto';
 import { TransactionEntity } from '../../transaction/entities/transaction.entity';
 import { Transaction } from '../../transaction/interface/transaction.interface';
 
+/**
+ * Original GARMS Transaction formatting
+ *
+ */
 export class GarmsTransactionDTO {
   @ApiProperty({
     description: 'Unique id representing the transaction in the source system',

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -57,7 +57,6 @@ export class GarmsTransactionDTO {
   @ApiProperty({ description: 'Total Value of the Txn', example: 150.5 })
   @IsNumber()
   @IsNotEmpty()
-  @Min(0.01)
   total_transaction_amount!: number;
 
   @ApiProperty({ description: 'Transaction Cancelled', example: true })
@@ -96,12 +95,6 @@ export class GarmsTransactionDTO {
   @ArrayMinSize(1, {
     message: 'At least 1 Payment Method Required',
   })
-  @ArrayUnique(
-    (o: GarmsPaymentDTO) => {
-      return o.payment_method;
-    },
-    { message: 'Payment Method items must be unique' }
-  )
   @Validate(ArePaymentMethodsValid)
   payments!: GarmsPaymentDTO[];
 

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -68,7 +68,7 @@ export class GarmsTransactionDTO {
   source_id!: string;
 
   @ApiProperty({ description: 'Location ID', example: '47' })
-  @IsNumber()
+  @IsString()
   @IsNotEmpty()
   location_id!: string;
 

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -14,16 +14,14 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { Transaction } from '../../transaction/interface/transaction.interface';
-import { TransactionEntity } from '../../transaction/entities/transaction.entity';
-import { PaymentDTO } from '../../transaction/dto/payment.dto';
 import { GarmsPaymentDTO } from './garms-payment.dto';
-import { PaymentEntity } from '../../transaction/entities';
+import { TransactionEntity } from '../../transaction/entities/transaction.entity';
+import { Transaction } from '../../transaction/interface/transaction.interface';
 
 export class GarmsTransactionDTO {
   @ApiProperty({
     description: 'Unique id representing the transaction in the source system',
-    example: '264595a1-4775-4bfe-9b3a-358bbbb5c4f7',
+    example: '20230530-00001-1000001',
   })
   @IsString()
   @IsNotEmpty()
@@ -74,7 +72,7 @@ export class GarmsTransactionDTO {
   transactionJson: Transaction;
 
   @ApiProperty({ description: 'Migrated', example: false })
-  migrated: boolean = false;
+  migrated = false;
 
   @ApiProperty({
     description: 'Source File Name',

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -12,11 +12,13 @@ import {
   IsOptional,
   IsString,
   Min,
+  Validate,
   ValidateNested,
 } from 'class-validator';
 import { GarmsPaymentDTO } from './garms-payment.dto';
 import { TransactionEntity } from '../../transaction/entities/transaction.entity';
 import { Transaction } from '../../transaction/interface/transaction.interface';
+import { ArePaymentMethodsValid } from 'src/transaction/decorators/arePaymentMethodsValid';
 
 /**
  * Original GARMS Transaction formatting
@@ -68,9 +70,9 @@ export class GarmsTransactionDTO {
   source_id!: string;
 
   @ApiProperty({ description: 'Location ID', example: '47' })
-  @IsString()
+  @IsNumber()
   @IsNotEmpty()
-  location_id!: string;
+  location_id!: number;
 
   @ApiProperty({ description: 'TransactionJSON', type: Transaction })
   transactionJson: Transaction;
@@ -100,6 +102,7 @@ export class GarmsTransactionDTO {
     },
     { message: 'Payment Method items must be unique' }
   )
+  @Validate(ArePaymentMethodsValid)
   payments!: GarmsPaymentDTO[];
 
   constructor(transaction?: Partial<TransactionEntity>) {

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -18,7 +18,7 @@ import {
 import { GarmsPaymentDTO } from './garms-payment.dto';
 import { TransactionEntity } from '../../transaction/entities/transaction.entity';
 import { Transaction } from '../../transaction/interface/transaction.interface';
-import { ArePaymentMethodsValid } from 'src/transaction/decorators/arePaymentMethodsValid';
+import { ArePaymentMethodsValid } from '../../transaction/decorators/arePaymentMethodsValid';
 
 /**
  * Original GARMS Transaction formatting

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -92,9 +92,6 @@ export class GarmsTransactionDTO {
   @ValidateNested({ each: true })
   @Type(() => GarmsPaymentDTO)
   @IsArray()
-  @ArrayMinSize(1, {
-    message: 'At least 1 Payment Method Required',
-  })
   @Validate(ArePaymentMethodsValid)
   payments!: GarmsPaymentDTO[];
 

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -1,0 +1,117 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsDefined,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Transaction } from '../../transaction/interface/transaction.interface';
+import { TransactionEntity } from '../../transaction/entities/transaction.entity';
+import { PaymentDTO } from '../../transaction/dto/payment.dto';
+import { GarmsPaymentDTO } from './garms-payment.dto';
+import { PaymentEntity } from '../../transaction/entities';
+
+export class GarmsTransactionDTO {
+  @ApiProperty({
+    description: 'Unique id representing the transaction in the source system',
+    example: '264595a1-4775-4bfe-9b3a-358bbbb5c4f7',
+  })
+  @IsString()
+  @IsNotEmpty()
+  transaction_id!: string;
+
+  @ApiProperty({ description: 'Transaction Date', example: '2022-10-25' })
+  @IsString()
+  @IsNotEmpty()
+  @IsDateString({
+    strict: true,
+  })
+  transaction_date!: string;
+
+  @ApiProperty({ description: 'Transaction Time', example: '13.33.31.875973' })
+  @IsString()
+  @IsNotEmpty()
+  transaction_time!: string;
+
+  @ApiProperty({ description: 'Fiscal Close Date', example: '2022-10-25' })
+  @IsString()
+  @IsNotEmpty()
+  @IsDateString({
+    strict: true,
+  })
+  fiscal_close_date!: string;
+
+  @ApiProperty({ description: 'Total Value of the Txn', example: 150.5 })
+  @IsNumber()
+  @IsNotEmpty()
+  @Min(0.01)
+  total_transaction_amount!: number;
+
+  @ApiProperty({ description: 'Transaction Cancelled', example: true })
+  @IsBoolean()
+  void_indicator?: boolean = false;
+
+  @ApiProperty({ description: 'Program Source ID', example: 'SBC' })
+  @IsString()
+  @IsNotEmpty()
+  source_id!: string;
+
+  @ApiProperty({ description: 'Location ID', example: '47' })
+  @IsString()
+  @IsNotEmpty()
+  location_id!: string;
+
+  @ApiProperty({ description: 'TransactionJSON', type: Transaction })
+  transactionJson: Transaction;
+
+  @ApiProperty({ description: 'Migrated', example: false })
+  migrated: boolean = false;
+
+  @ApiProperty({
+    description: 'Source File Name',
+    example: 'sbc/SBC_SALES_2023_05_08_23_18_08.JSON',
+  })
+  @IsOptional()
+  source_file_name?: string;
+
+  @ApiProperty({ description: 'Payments', type: GarmsPaymentDTO })
+  @IsDefined()
+  @IsNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => GarmsPaymentDTO)
+  @IsArray()
+  @ArrayMinSize(1, {
+    message: 'At least 1 Payment Method Required',
+  })
+  @ArrayUnique(
+    (o: GarmsPaymentDTO) => {
+      return o.payment_method;
+    },
+    { message: 'Payment Method items must be unique' }
+  )
+  payments!: GarmsPaymentDTO[];
+
+  constructor(transaction?: Partial<TransactionEntity>) {
+    Object.assign(this, transaction);
+    this.payments =
+      transaction?.payments?.map((p) => new GarmsPaymentDTO(p)) || [];
+  }
+}
+
+export class GarmsTransactionList {
+  @ValidateNested({ each: true })
+  list: GarmsTransactionDTO[];
+
+  constructor(transactions: GarmsTransactionDTO[]) {
+    this.list = transactions;
+  }
+}

--- a/apps/backend/src/parse/dto/garms-transaction.dto.ts
+++ b/apps/backend/src/parse/dto/garms-transaction.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   ArrayMinSize,
-  ArrayUnique,
   IsArray,
   IsBoolean,
   IsDateString,
@@ -11,14 +10,13 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  Min,
   Validate,
   ValidateNested,
 } from 'class-validator';
 import { GarmsPaymentDTO } from './garms-payment.dto';
+import { ArePaymentMethodsValid } from '../../transaction/decorators/arePaymentMethodsValid';
 import { TransactionEntity } from '../../transaction/entities/transaction.entity';
 import { Transaction } from '../../transaction/interface/transaction.interface';
-import { ArePaymentMethodsValid } from '../../transaction/decorators/arePaymentMethodsValid';
 
 /**
  * Original GARMS Transaction formatting

--- a/apps/backend/src/parse/dto/pos-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/pos-deposit.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsOptional,
   IsString,
   IsNotEmpty,
   IsDateString,
@@ -9,8 +8,8 @@ import {
   IsNumber,
   Length,
 } from 'class-validator';
-import { PaymentMethodEntity } from '../../transaction/entities';
 import { POSDepositEntity } from '../../deposits/entities/pos-deposit.entity';
+import { PaymentMethodEntity } from '../../transaction/entities';
 
 export class PosDepositDTO {
   //source file type

--- a/apps/backend/src/parse/dto/pos-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/pos-deposit.dto.ts
@@ -25,9 +25,9 @@ export class PosDepositDTO {
   card_id!: string;
 
   @ApiProperty({ description: 'Transaction Amount', example: '25.00' })
-  @IsNumberString()
+  @IsNumber()
   @IsNotEmpty()
-  transaction_amt!: string;
+  transaction_amt!: number;
 
   @ApiProperty({ description: 'Transaction Date', example: '2023-01-01' })
   @IsDateString()

--- a/apps/backend/src/parse/dto/pos-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/pos-deposit.dto.ts
@@ -14,11 +14,11 @@ import { PaymentMethodEntity } from '../../transaction/entities';
 export class PosDepositDTO {
   //source file type
 
-  @ApiProperty({ description: 'Merchant ID', example: '22044859' })
+  @ApiProperty({ description: 'Merchant ID', example: '22099999' })
   @IsNumber()
   merchant_id!: string;
 
-  @ApiProperty({ description: 'Card Id', example: '***************6194' })
+  @ApiProperty({ description: 'Card Id', example: '***************5368' })
   @IsString()
   @IsNotEmpty()
   @Length(19)
@@ -40,7 +40,7 @@ export class PosDepositDTO {
 
   @ApiProperty({
     description: 'Terminal Number',
-    example: 'GA2204318206',
+    example: 'GA2209999999',
   })
   @IsString()
   @IsNotEmpty()

--- a/apps/backend/src/parse/dto/pos-deposit.dto.ts
+++ b/apps/backend/src/parse/dto/pos-deposit.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  IsNotEmpty,
+  IsDateString,
+  IsNumberString,
+  ValidateNested,
+  IsNumber,
+  Length,
+} from 'class-validator';
+import { PaymentMethodEntity } from '../../transaction/entities';
+import { POSDepositEntity } from '../../deposits/entities/pos-deposit.entity';
+
+export class PosDepositDTO {
+  //source file type
+
+  @ApiProperty({ description: 'Merchant ID', example: '22044859' })
+  @IsNumber()
+  merchant_id!: string;
+
+  @ApiProperty({ description: 'Card Id', example: '***************6194' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(19)
+  card_id!: string;
+
+  @ApiProperty({ description: 'Transaction Amount', example: '25.00' })
+  @IsNumberString()
+  @IsNotEmpty()
+  transaction_amt!: string;
+
+  @ApiProperty({ description: 'Transaction Date', example: '2023-01-01' })
+  @IsDateString()
+  @IsNotEmpty()
+  transaction_date!: string;
+
+  @ApiProperty({ description: 'Transaction Time', example: '162000' })
+  @IsNumberString()
+  transaction_time!: string;
+
+  @ApiProperty({
+    description: 'Terminal Number',
+    example: 'GA2204318206',
+  })
+  @IsString()
+  @IsNotEmpty()
+  terminal_no!: string;
+
+  @ApiProperty({ description: 'Payment Method', type: PaymentMethodEntity })
+  @IsNotEmpty()
+  payment_method!: PaymentMethodEntity;
+
+  constructor(posDeposit?: Partial<POSDepositEntity>) {
+    Object.assign(this, posDeposit);
+  }
+}
+
+export class PosDepositListDTO {
+  @ValidateNested({ each: true })
+  list: PosDepositDTO[];
+
+  constructor(posDeposits: PosDepositDTO[]) {
+    this.list = posDeposits;
+  }
+}

--- a/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
+++ b/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
@@ -1,0 +1,24 @@
+import { Column, PrimaryGeneratedColumn, Entity } from 'typeorm';
+import { Ministries } from '../../constants';
+
+@Entity('file_ingestion_rules')
+export class FileIngestionRulesEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  program: string;
+
+  @Column({ nullable: false })
+  cashChequesFilename?: string; // TDI17
+
+  @Column({ nullable: false })
+  cardsFilename?: string; // TDI34
+
+  @Column({ nullable: false })
+  transactionsFilename?: string;
+
+  // Number of retries before we send an alert
+  @Column({ type: 'int4', default: 0 })
+  retries: number;
+}

--- a/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
+++ b/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
@@ -1,5 +1,4 @@
 import { Column, PrimaryGeneratedColumn, Entity } from 'typeorm';
-import { Ministries } from '../../constants';
 
 @Entity('file_ingestion_rules')
 export class FileIngestionRulesEntity {
@@ -9,13 +8,13 @@ export class FileIngestionRulesEntity {
   @Column()
   program: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   cashChequesFilename?: string; // TDI17
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   cardsFilename?: string; // TDI34
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   transactionsFilename?: string;
 
   // Number of retries before we send an alert

--- a/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
+++ b/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
@@ -8,13 +8,13 @@ export class FileIngestionRulesEntity {
   @Column()
   program: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, name: 'cash_cheques_filename' })
   cashChequesFilename?: string; // TDI17
 
-  @Column({ nullable: true })
-  cardsFilename?: string; // TDI34
+  @Column({ nullable: true, name: 'pos_filename' })
+  posFilename?: string; // TDI34
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, name: 'transactions_filename' })
   transactionsFilename?: string;
 
   // Number of retries before we send an alert

--- a/apps/backend/src/parse/entities/file-uploaded.entity.ts
+++ b/apps/backend/src/parse/entities/file-uploaded.entity.ts
@@ -6,8 +6,8 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
-import { FileTypes } from '../../constants';
 import { ProgramDailyUploadEntity } from './program-daily-upload.entity';
+import { FileTypes } from '../../constants';
 
 @Entity('file_uploaded')
 export class FileUploadedEntity {

--- a/apps/backend/src/parse/entities/file-uploaded.entity.ts
+++ b/apps/backend/src/parse/entities/file-uploaded.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  Entity,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { FileTypes } from '../../constants';
+import { ProgramDailyUploadEntity } from './program-daily-upload.entity';
+
+@Entity('file_uploaded')
+export class FileUploadedEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @Column({ enum: FileTypes, default: FileTypes.TDI17 })
+  source_file_type: FileTypes;
+
+  @Column()
+  source_file_name: string;
+
+  @Column({ type: 'int4' })
+  source_file_length: number;
+
+  @ManyToOne(
+    () => ProgramDailyUploadEntity,
+    (programDailyUpload) => programDailyUpload.files
+  )
+  @JoinColumn()
+  programFiles: ProgramDailyUploadEntity;
+}

--- a/apps/backend/src/parse/entities/file-uploaded.entity.ts
+++ b/apps/backend/src/parse/entities/file-uploaded.entity.ts
@@ -5,6 +5,7 @@ import {
   Entity,
   ManyToOne,
   JoinColumn,
+  Relation,
 } from 'typeorm';
 import { ProgramDailyUploadEntity } from './program-daily-upload.entity';
 import { FileTypes } from '../../constants';
@@ -17,19 +18,23 @@ export class FileUploadedEntity {
   @CreateDateColumn()
   created_at: Date;
 
-  @Column({ enum: FileTypes, default: FileTypes.TDI17 })
-  source_file_type: FileTypes;
+  @Column({
+    enum: FileTypes,
+    default: FileTypes.TDI17,
+    name: 'source_file_type',
+  })
+  sourceFileType: FileTypes;
 
-  @Column()
-  source_file_name: string;
+  @Column({ name: 'source_file_name' })
+  sourceFileName: string;
 
-  @Column({ type: 'int4' })
-  source_file_length: number;
+  @Column({ type: 'int4', name: 'source_file_length' })
+  sourceFileLength: number;
 
   @ManyToOne(
     () => ProgramDailyUploadEntity,
     (programDailyUpload) => programDailyUpload.files
   )
-  @JoinColumn()
-  programFiles: ProgramDailyUploadEntity;
+  @JoinColumn({ name: 'daily_upload_id' })
+  dailyUpload: Relation<ProgramDailyUploadEntity>;
 }

--- a/apps/backend/src/parse/entities/program-daily-upload.entity.ts
+++ b/apps/backend/src/parse/entities/program-daily-upload.entity.ts
@@ -7,8 +7,8 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
-import { FileUploadedEntity } from './file-uploaded.entity';
 import { FileIngestionRulesEntity } from './file-ingestion-rules.entity';
+import { FileUploadedEntity } from './file-uploaded.entity';
 
 @Entity('program_daily_upload')
 export class ProgramDailyUploadEntity {
@@ -19,7 +19,7 @@ export class ProgramDailyUploadEntity {
   created_at: Date;
 
   @Column({ type: 'date' })
-  dataDate: Date;
+  dataDate: string;
 
   @Column()
   success: boolean;

--- a/apps/backend/src/parse/entities/program-daily-upload.entity.ts
+++ b/apps/backend/src/parse/entities/program-daily-upload.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  Entity,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { FileUploadedEntity } from './file-uploaded.entity';
+import { FileIngestionRulesEntity } from './file-ingestion-rules.entity';
+
+@Entity('program_daily_upload')
+export class ProgramDailyUploadEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @Column({ type: 'date' })
+  dataDate: Date;
+
+  @Column()
+  success: boolean;
+
+  // Number of times we have tried uploading this grouping for a day
+  @Column({ type: 'int4' })
+  retries: number;
+
+  @ManyToOne(() => FileIngestionRulesEntity)
+  @JoinColumn()
+  rule: FileIngestionRulesEntity;
+
+  @OneToMany(
+    () => FileUploadedEntity,
+    (fileUploaded) => fileUploaded.programFiles
+  )
+  files: FileUploadedEntity[];
+}

--- a/apps/backend/src/parse/entities/program-daily-upload.entity.ts
+++ b/apps/backend/src/parse/entities/program-daily-upload.entity.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   ManyToOne,
   JoinColumn,
+  Relation,
 } from 'typeorm';
 import { FileIngestionRulesEntity } from './file-ingestion-rules.entity';
 import { FileUploadedEntity } from './file-uploaded.entity';
@@ -18,8 +19,8 @@ export class ProgramDailyUploadEntity {
   @CreateDateColumn()
   created_at: Date;
 
-  @Column({ type: 'date' })
-  dataDate: string;
+  @Column({ type: 'date', name: 'daily_date' })
+  dailyDate: string;
 
   @Column()
   success: boolean;
@@ -30,11 +31,11 @@ export class ProgramDailyUploadEntity {
 
   @ManyToOne(() => FileIngestionRulesEntity)
   @JoinColumn()
-  rule: FileIngestionRulesEntity;
+  rule: Relation<FileIngestionRulesEntity>;
 
   @OneToMany(
     () => FileUploadedEntity,
-    (fileUploaded) => fileUploaded.programFiles
+    (fileUploaded) => fileUploaded.dailyUpload
   )
-  files: FileUploadedEntity[];
+  files: Relation<FileUploadedEntity[]>;
 }

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -253,7 +253,7 @@ export class ParseController {
             (file) => file.source_file_type === FileTypes.SBC_SALES
           ) || false;
       }
-      if (!hasTdi17 || !cardsFilename || !hasTransactionFile) {
+      if (!hasTdi17 || !hasTdi34 || !hasTransactionFile) {
         success = false;
       }
       if (success === true) {

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -21,6 +21,7 @@ import { PosDepositService } from '../deposits/pos-deposit.service';
 import { AppLogger } from '../logger/logger.service';
 import { TransactionEntity } from '../transaction/entities';
 import { TransactionService } from '../transaction/transaction.service';
+import { parseISO } from 'date-fns';
 
 @Controller('parse')
 @ApiTags('Parser API')
@@ -207,12 +208,15 @@ export class ParseController {
    * Called at the start of a parser lambda run
    */
   @Post('daily-upload')
-  async commenceDailyUpload(@Body() body: { date: Date }): Promise<void> {
+  async commenceDailyUpload(@Body() body: { date: string }): Promise<void> {
     const rules = await this.parseService.getAllRules();
     for (const rule of rules) {
-      const daily = await this.parseService.getDailyForRule(rule, body.date);
+      const daily = await this.parseService.getDailyForRule(
+        rule,
+        new Date(body.date)
+      );
       if (!daily) {
-        await this.parseService.createNewDaily(rule, body.date);
+        await this.parseService.createNewDaily(rule, new Date(body.date));
       }
     }
   }
@@ -227,9 +231,15 @@ export class ParseController {
     const rules = await this.parseService.getAllRules();
     const dailyAlertPrograms = [];
     for (const rule of rules) {
-      let daily = await this.parseService.getDailyForRule(rule, body.date);
+      let daily = await this.parseService.getDailyForRule(
+        rule,
+        new Date(body.date)
+      );
       if (!daily) {
-        daily = await this.parseService.createNewDaily(rule, body.date);
+        daily = await this.parseService.createNewDaily(
+          rule,
+          new Date(body.date)
+        );
       }
       if (daily.success) {
         dailyAlertPrograms.push({

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -21,7 +21,6 @@ import { PosDepositService } from '../deposits/pos-deposit.service';
 import { AppLogger } from '../logger/logger.service';
 import { TransactionEntity } from '../transaction/entities';
 import { TransactionService } from '../transaction/transaction.service';
-import { parseISO } from 'date-fns';
 
 @Controller('parse')
 @ApiTags('Parser API')
@@ -194,12 +193,12 @@ export class ParseController {
         );
       }
     } catch (err: unknown) {
-      throw new BadRequestException({
-        message:
-          err instanceof Error
-            ? err.message
-            : `Error with processing ${fileName}`,
-      });
+      const message =
+        err instanceof Error
+          ? err.message
+          : `Error with processing ${fileName}`;
+      this.appLogger.log(message);
+      throw new BadRequestException({ message });
     }
   }
 

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -14,15 +14,13 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiConsumes, ApiBody, ApiTags } from '@nestjs/swagger';
 import { ParseService } from './parse.service';
-import { FileTypes } from '../constants';
-import { AppLogger } from '../logger/logger.service';
-import { TransactionEntity } from '../transaction/entities';
-import { FileUploadedEntity } from './entities/file-uploaded.entity';
-import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
 import { DailyAlertRO } from './ro/daily-alert.ro';
-import { TransactionService } from '../transaction/transaction.service';
+import { FileTypes } from '../constants';
 import { CashDepositService } from '../deposits/cash-deposit.service';
 import { PosDepositService } from '../deposits/pos-deposit.service';
+import { AppLogger } from '../logger/logger.service';
+import { TransactionEntity } from '../transaction/entities';
+import { TransactionService } from '../transaction/transaction.service';
 
 @Controller('parse')
 @ApiTags('Parser API')

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -275,7 +275,7 @@ export class ParseController {
         });
         dailyAlertPrograms.push({
           program: rule.program,
-          success: true,
+          success: false,
           alerted,
         });
       }

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -112,6 +112,14 @@ export class ParseController {
     this.appLogger.log(`Parsing ${fileName} - ${fileType}`);
     const contents = file.buffer.toString();
 
+    const allFiles = await this.parseService.getAllFiles();
+    const allFilenames = new Set(allFiles.map((f) => f.sourceFileName));
+    if (allFilenames.has(fileName)) {
+      throw new BadRequestException({
+        message: 'Invalid filename, this already exists',
+      });
+    }
+
     // Throws an error if no rules exist for the specified program
     const rules = await this.parseService.getRulesForProgram(program);
     if (!rules) {

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -130,10 +130,10 @@ export class ParseController {
         const garmsSales: TransactionEntity[] =
           await this.parseService.parseGarmsFile(contents, fileName);
         const fileToSave = await this.parseService.saveFileUploaded({
-          source_file_type: fileType,
-          source_file_name: fileName,
-          source_file_length: garmsSales.length,
-          programFiles: daily,
+          sourceFileType: fileType,
+          sourceFileName: fileName,
+          sourceFileLength: garmsSales.length,
+          dailyUpload: daily,
         });
         this.appLogger.log(`txn count: ${garmsSales.length}`);
         await this.transactionService.saveTransactions(
@@ -153,10 +153,10 @@ export class ParseController {
           file.buffer
         );
         const fileToSave = await this.parseService.saveFileUploaded({
-          source_file_type: fileType,
-          source_file_name: fileName,
-          source_file_length: cashDeposits.length,
-          programFiles: daily,
+          sourceFileType: fileType,
+          sourceFileName: fileName,
+          sourceFileLength: cashDeposits.length,
+          dailyUpload: daily,
         });
         await this.cashDepositService.saveCashDepositEntities(
           cashDeposits.map((deposit) => ({
@@ -175,10 +175,10 @@ export class ParseController {
           file.buffer
         );
         const fileToSave = await this.parseService.saveFileUploaded({
-          source_file_type: fileType,
-          source_file_name: fileName,
-          source_file_length: posEntities.length,
-          programFiles: daily,
+          sourceFileType: fileType,
+          sourceFileName: fileName,
+          sourceFileLength: posEntities.length,
+          dailyUpload: daily,
         });
         await this.posDepositService.savePOSDepositEntities(
           posEntities.map((deposit) => ({
@@ -228,7 +228,7 @@ export class ParseController {
         });
         continue;
       }
-      const { cashChequesFilename, cardsFilename, transactionsFilename } = rule;
+      const { cashChequesFilename, posFilename, transactionsFilename } = rule;
       const files = daily.files;
       // For each required file type, check if the file exists
       let hasTdi17 = false,
@@ -237,19 +237,18 @@ export class ParseController {
       let success = true;
       if (cashChequesFilename) {
         hasTdi17 =
-          files?.some((file) => file.source_file_type === FileTypes.TDI17) ||
+          files?.some((file) => file.sourceFileType === FileTypes.TDI17) ||
           false;
       }
-      if (cardsFilename) {
+      if (posFilename) {
         hasTdi34 =
-          files?.some((file) => file.source_file_type === FileTypes.TDI34) ||
+          files?.some((file) => file.sourceFileType === FileTypes.TDI34) ||
           false;
       }
       if (transactionsFilename) {
         hasTransactionFile =
-          files?.some(
-            (file) => file.source_file_type === FileTypes.SBC_SALES
-          ) || false;
+          files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES) ||
+          false;
       }
       if (!hasTdi17 || !hasTdi34 || !hasTransactionFile) {
         success = false;

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -215,7 +215,6 @@ export class ParseController {
         await this.parseService.createNewDaily(rule, body.date);
       }
     }
-    return;
   }
 
   /**
@@ -240,31 +239,10 @@ export class ParseController {
         });
         continue;
       }
-      const { cashChequesFilename, posFilename, transactionsFilename } = rule;
-      const files = daily.files;
-      // For each required file type, check if the file exists
-      let hasTdi17 = false,
-        hasTdi34 = false,
-        hasTransactionFile = false;
-      let success = true;
-      if (cashChequesFilename) {
-        hasTdi17 =
-          files?.some((file) => file.sourceFileType === FileTypes.TDI17) ||
-          false;
-      }
-      if (posFilename) {
-        hasTdi34 =
-          files?.some((file) => file.sourceFileType === FileTypes.TDI34) ||
-          false;
-      }
-      if (transactionsFilename) {
-        hasTransactionFile =
-          files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES) ||
-          false;
-      }
-      if (!hasTdi17 || !hasTdi34 || !hasTransactionFile) {
-        success = false;
-      }
+      const success = this.parseService.determineDailySuccess(
+        rule,
+        daily.files
+      );
       if (success === true) {
         await this.parseService.saveDaily({
           ...daily,

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -130,7 +130,7 @@ export class ParseController {
         const fileToSave = await this.parseService.saveFileUploaded({
           source_file_type: fileType,
           source_file_name: fileName,
-          source_file_length: file.buffer.length,
+          source_file_length: garmsSales.length,
           programFiles: daily,
         });
         this.appLogger.log(`txn count: ${garmsSales.length}`);
@@ -150,8 +150,18 @@ export class ParseController {
           program,
           file.buffer
         );
-        this.appLogger.log(cashDeposits);
-        await this.cashDepositService.saveCashDepositEntities(cashDeposits);
+        const fileToSave = await this.parseService.saveFileUploaded({
+          source_file_type: fileType,
+          source_file_name: fileName,
+          source_file_length: cashDeposits.length,
+          programFiles: daily,
+        });
+        await this.cashDepositService.saveCashDepositEntities(
+          cashDeposits.map((deposit) => ({
+            ...deposit,
+            fileUploadedEntity: fileToSave,
+          }))
+        );
       }
 
       if (fileType === FileTypes.TDI34) {
@@ -162,7 +172,19 @@ export class ParseController {
           program,
           file.buffer
         );
-        await this.posDepositService.savePOSDepositEntities(posEntities);
+        const fileToSave = await this.parseService.saveFileUploaded({
+          source_file_type: fileType,
+          source_file_name: fileName,
+          source_file_length: posEntities.length,
+          programFiles: daily,
+        });
+        await this.posDepositService.savePOSDepositEntities(
+          posEntities.map((deposit) => ({
+            ...deposit,
+            fileUploadedEntity: fileToSave,
+            timestamp: deposit.timestamp,
+          }))
+        );
       }
     } catch (err: any) {
       // Throw

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -13,6 +13,7 @@ import { ApiConsumes, ApiBody, ApiTags } from '@nestjs/swagger';
 import { ParseService } from './parse.service';
 import { FileTypes } from '../constants';
 import { AppLogger } from '../logger/logger.service';
+import { TransactionEntity } from '../transaction/entities';
 
 @Controller('parse')
 @ApiTags('Parser API')
@@ -60,5 +61,77 @@ export class ParseController {
       program: body.program,
       fileContents: contents,
     });
+  }
+
+  @Post('upload-file')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        fileName: {
+          type: 'string',
+          nullable: false,
+        },
+        fileType: {
+          type: 'string',
+          enum: ['TDI17', 'TDI34', 'SBC_SALES'],
+          nullable: false,
+        },
+        program: {
+          type: 'string',
+          enum: ['SBC', 'LABOUR'],
+          nullable: false,
+        },
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAndParseFile(
+    @Body() body: { fileName: string; fileType: FileTypes; program: string },
+    @UploadedFile() file: Express.Multer.File
+  ) {
+    const { fileName, fileType, program } = body;
+    this.appLogger.log(`PARSE PARSE PARSE ${fileName} - ${fileType}`);
+    const contents = file.buffer.toString();
+    if (fileType === FileTypes.SBC_SALES) {
+      this.appLogger.log('Parse and store SBC Sales in DB...', fileName);
+      // Parse and validate rows from Garms
+      const garmsSales: TransactionEntity[] =
+        await this.parseService.parseGarmsFile(contents, fileName);
+      this.appLogger.log(`txn count: ${garmsSales.length}`);
+      // await this.transactionService.saveTransactions(garmsSales);
+    }
+
+    if (fileType === FileTypes.TDI17) {
+      this.appLogger.log('Parse and store TDI17 in DB...', fileName);
+      const cashDeposits = await this.parseService.parseTDICashFile(
+        fileType,
+        fileName,
+        program,
+        file.buffer
+      );
+      // save
+      // await cashService.saveCashDepositEntities(cashDeposits);
+    }
+
+    if (fileType === FileTypes.TDI34) {
+      this.appLogger.log('Parse and store TDI34 in DB...', fileName);
+      const posEntities = await this.parseService.parseTDICardsFile(
+        fileType,
+        fileName,
+        program,
+        file.buffer
+      );
+      // save
+      // await posService.savePOSDepositEntities(posEntities);
+    }
+  }
+  catch(err: any) {
+    this.appLogger.error(err);
   }
 }

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -1,10 +1,21 @@
 import { Logger, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { TransactionModule } from '../transaction/transaction.module';
+import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
+import { FileUploadedEntity } from './entities/file-uploaded.entity';
+import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
 import { ParseController } from './parse.controller';
 import { ParseService } from './parse.service';
 
 @Module({
-  imports: [TransactionModule],
+  imports: [
+    TransactionModule,
+    TypeOrmModule.forFeature([
+      FileUploadedEntity,
+      FileIngestionRulesEntity,
+      ProgramDailyUploadEntity,
+    ]),
+  ],
   controllers: [ParseController],
   providers: [ParseService, Logger],
 })

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -1,12 +1,12 @@
 import { Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DepositModule } from '../deposits/deposit.module';
-import { TransactionModule } from '../transaction/transaction.module';
 import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
 import { FileUploadedEntity } from './entities/file-uploaded.entity';
 import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
 import { ParseController } from './parse.controller';
 import { ParseService } from './parse.service';
+import { DepositModule } from '../deposits/deposit.module';
+import { TransactionModule } from '../transaction/transaction.module';
 
 @Module({
   imports: [

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -1,8 +1,10 @@
 import { Logger, Module } from '@nestjs/common';
+import { TransactionModule } from '../transaction/transaction.module';
 import { ParseController } from './parse.controller';
 import { ParseService } from './parse.service';
 
 @Module({
+  imports: [TransactionModule],
   controllers: [ParseController],
   providers: [ParseService, Logger],
 })

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -1,5 +1,6 @@
 import { Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { DepositModule } from '../deposits/deposit.module';
 import { TransactionModule } from '../transaction/transaction.module';
 import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
 import { FileUploadedEntity } from './entities/file-uploaded.entity';
@@ -9,6 +10,7 @@ import { ParseService } from './parse.service';
 
 @Module({
   imports: [
+    DepositModule,
     TransactionModule,
     TypeOrmModule.forFeature([
       FileUploadedEntity,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -52,7 +52,10 @@ export class ParseService {
         ? error[0].children
             .map(
               (child: ValidationError) =>
-                `${errantColumnName} ${child.value?.[errantIdColumnName]}`
+                `${errantColumnName} ${
+                  child.value?.[errantIdColumnName] ||
+                  child.value?.metadata?.[errantIdColumnName]
+                }`
             )
             .join('; ')
         : '';
@@ -85,7 +88,6 @@ export class ParseService {
       fileName,
       paymentMethods
     );
-    // CLEAN UP HERE??
     const garmsSalesDTO = garmsSales.map((t) => new GarmsTransactionDTO(t));
     const list = new GarmsTransactionList(garmsSalesDTO);
     try {
@@ -122,8 +124,11 @@ export class ParseService {
     const cashDepositsDto = cashDeposits.map((c) => new CashDepositDTO(c));
     const list = new CashDepositsListDTO(cashDepositsDto);
     try {
+      console.log(typeof cashDeposits[0].deposit_amt_cdn);
+      console.log(typeof list.list[0].deposit_amt_cdn);
       await validateOrReject(list);
-    } catch (e: unknown) {
+    } catch (e: any) {
+      console.log(e[0].children[0].children);
       this.handleValidationError(
         e,
         fileName,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -48,26 +48,19 @@ export class ParseService {
     files: FileUploadedEntity[]
   ): boolean {
     const { cashChequesFilename, posFilename, transactionsFilename } = rule;
-    let hasTdi17 = false,
-      hasTdi34 = false,
-      hasTransactionFile = false;
-    let success = true;
-    if (cashChequesFilename) {
-      hasTdi17 =
-        files?.some((file) => file.sourceFileType === FileTypes.TDI17) || false;
-    }
-    if (posFilename) {
-      hasTdi34 =
-        files?.some((file) => file.sourceFileType === FileTypes.TDI34) || false;
-    }
-    if (transactionsFilename) {
-      hasTransactionFile =
-        files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES) ||
-        false;
-    }
-    if (!hasTdi17 || !hasTdi34 || !hasTransactionFile) {
-      success = false;
-    }
+    const hasTdi17 =
+      (cashChequesFilename &&
+        !files?.some((file) => file.sourceFileType === FileTypes.TDI17)) ||
+      true;
+    const hasTdi34 =
+      (posFilename &&
+        !files?.some((file) => file.sourceFileType === FileTypes.TDI34)) ||
+      true;
+    const hasTransactionFile =
+      (transactionsFilename &&
+        !files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES)) ||
+      true;
+    let success = !hasTdi17 || !hasTdi34 || !hasTransactionFile;
     return success;
   }
 

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -1,11 +1,8 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
-import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { validateOrReject, ValidationError } from 'class-validator';
-import { FileUploadedEntity } from './entities/file-uploaded.entity';
+import { format } from 'date-fns';
 import { Repository } from 'typeorm';
-import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
 import { CashDepositDTO, CashDepositsListDTO } from './dto/cash-deposit.dto';
 import {
   GarmsTransactionDTO,
@@ -13,7 +10,11 @@ import {
 } from './dto/garms-transaction.dto';
 import { PosDepositDTO, PosDepositListDTO } from './dto/pos-deposit.dto';
 import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
+import { FileUploadedEntity } from './entities/file-uploaded.entity';
+import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
 import { FileTypes, ParseArgsTDI } from '../constants';
+import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
+import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 import { TDI17Details, TDI34Details } from '../flat-files';
 import { parseGarms } from '../lambdas/utils/parseGarms';
 import { parseTDI } from '../lambdas/utils/parseTDI';
@@ -21,7 +22,6 @@ import { AppLogger } from '../logger/logger.service';
 import { TransactionEntity } from '../transaction/entities';
 import { SBCGarmsJson } from '../transaction/interface';
 import { PaymentMethodService } from '../transaction/payment-method.service';
-import { format } from 'date-fns';
 
 @Injectable()
 export class ParseService {
@@ -60,7 +60,7 @@ export class ParseService {
       (transactionsFilename &&
         !files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES)) ||
       true;
-    let success = !hasTdi17 || !hasTdi34 || !hasTransactionFile;
+    const success = !hasTdi17 || !hasTdi34 || !hasTransactionFile;
     return success;
   }
 
@@ -145,7 +145,6 @@ export class ParseService {
         'Transaction Id',
         'transaction_id'
       );
-      this.appLogger.error(errorMessage);
       throw new Error(errorMessage);
     }
     return garmsSales;
@@ -186,7 +185,6 @@ export class ParseService {
         'Source File Line',
         'source_file_line'
       );
-      this.appLogger.error(errorMessage);
       throw new Error(errorMessage);
     }
     return cashDeposits;
@@ -227,7 +225,6 @@ export class ParseService {
         'Source File Line',
         'source_file_line'
       );
-      this.appLogger.error(errorMessage);
       throw new Error(errorMessage);
     }
     return posEntities;

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -231,6 +231,14 @@ export class ParseService {
   }
 
   /**
+   * Gets all files
+   * @returns List of uploaded files
+   */
+  async getAllFiles(): Promise<FileUploadedEntity[]> {
+    return this.uploadedRepo.find();
+  }
+
+  /**
    * Saves an entity into the Files Uploaded table.
    * Called whenever a file is uploaded by API or parser lambda
    * @param fileUploaded All the necessary information - sourceFileType, name, length, which daily upload to link to

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -21,6 +21,7 @@ import { AppLogger } from '../logger/logger.service';
 import { TransactionEntity } from '../transaction/entities';
 import { SBCGarmsJson } from '../transaction/interface';
 import { PaymentMethodService } from '../transaction/payment-method.service';
+import { format } from 'date-fns';
 
 @Injectable()
 export class ParseService {
@@ -84,6 +85,7 @@ export class ParseService {
       fileName,
       paymentMethods
     );
+    // CLEAN UP HERE??
     const garmsSalesDTO = garmsSales.map((t) => new GarmsTransactionDTO(t));
     const list = new GarmsTransactionList(garmsSalesDTO);
     try {
@@ -190,7 +192,7 @@ export class ParseService {
     return this.programDailyRepo.findOne({
       relations: ['rule', 'files'],
       where: {
-        dataDate: date,
+        dailyDate: format(date, 'yyyy-MM-dd'),
         rule: {
           id: rules.id,
         },
@@ -201,7 +203,7 @@ export class ParseService {
   async createNewDaily(rules: FileIngestionRulesEntity, date: Date) {
     try {
       const newDaily: Partial<ProgramDailyUploadEntity> = {
-        dataDate: date,
+        dailyDate: format(date, 'yyyy-MM-dd'),
         success: false,
         retries: 0,
         rule: rules,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -55,7 +55,7 @@ export class ParseService {
                 `${errantColumnName} ${
                   child.value?.[errantIdColumnName] ||
                   child.value?.metadata?.[errantIdColumnName]
-                }`
+                } - Issue with ${child.children?.[0]?.property}`
             )
             .join('; ')
         : '';

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -1,11 +1,27 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { ParseArgsTDI } from '../constants';
-import { parseTDI } from '../lambdas/utils/parseTDI';
 import { AppLogger } from '../logger/logger.service';
+import { SBCGarmsJson } from '../transaction/interface';
+import { FileTypes, Ministries, ParseArgsTDI } from '../constants';
+import { parseGarms } from '../lambdas/utils/parseGarms';
+import { parseTDI } from '../lambdas/utils/parseTDI';
+import { PaymentMethodService } from '../transaction/payment-method.service';
+import { TransactionEntity } from '../transaction/entities';
+import {
+  GarmsTransactionDTO,
+  GarmsTransactionList,
+} from './dto/garms-transaction.dto';
+import { validate, validateOrReject } from 'class-validator';
+import { TDI17Details, TDI34Details } from '../flat-files';
+import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
+import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
 
 @Injectable()
 export class ParseService {
-  constructor(@Inject(Logger) private readonly appLogger: AppLogger) {}
+  constructor(
+    @Inject(Logger) private readonly appLogger: AppLogger,
+    @Inject(PaymentMethodService)
+    private readonly paymentMethodService: PaymentMethodService
+  ) {}
 
   async readAndParseFile({
     type,
@@ -19,5 +35,70 @@ export class ParseService {
       this.appLogger.error(err, 'Error parsing file');
       throw err;
     }
+  }
+
+  async parseGarmsFile(
+    contents: string,
+    fileName: string
+  ): Promise<TransactionEntity[]> {
+    const paymentMethods = await this.paymentMethodService.getPaymentMethods();
+    const garmsSales = await parseGarms(
+      (await JSON.parse(contents || '{}')) as SBCGarmsJson[],
+      fileName,
+      paymentMethods
+    );
+    const garmsSalesDTO = garmsSales.map((t) => new GarmsTransactionDTO(t));
+    const list = new GarmsTransactionList(garmsSalesDTO);
+    try {
+      // BUG??
+      await validateOrReject(list);
+    } catch (e: any) {
+      this.appLogger.error('ERROR');
+      console.log(e[0]);
+      throw new Error('errrorr');
+    }
+    return garmsSales;
+  }
+
+  async parseTDICashFile(
+    type: FileTypes,
+    fileName: string,
+    program: string,
+    fileContents: Buffer
+  ): Promise<CashDepositEntity[]> {
+    const parsed = parseTDI({
+      type,
+      fileName,
+      program,
+      fileContents: Buffer.from(fileContents.toString() || '').toString(),
+    });
+
+    // validate
+    const tdi17Details = parsed as TDI17Details[];
+    const cashDeposits = tdi17Details.map(
+      (details) => new CashDepositEntity(details)
+    );
+    return cashDeposits;
+  }
+
+  async parseTDICardsFile(
+    type: FileTypes,
+    fileName: string,
+    program: string,
+    fileContents: Buffer
+  ): Promise<POSDepositEntity[]> {
+    const parsed = parseTDI({
+      type,
+      fileName,
+      program,
+      fileContents: Buffer.from(fileContents.toString() || '').toString(),
+    });
+
+    // validate
+    const tdi34Details = parsed as TDI34Details[];
+    const posEntities = tdi34Details.map(
+      (details) => new POSDepositEntity(details)
+    );
+    return posEntities;
   }
 }

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -151,7 +151,7 @@ export class ParseService {
 
     try {
       await validateOrReject(list);
-    } catch (e: any) {
+    } catch (e: unknown) {
       this.handleValidationError(
         e,
         fileName,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -1,26 +1,26 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { AppLogger } from '../logger/logger.service';
-import { SBCGarmsJson } from '../transaction/interface';
-import { FileTypes, ParseArgsTDI } from '../constants';
-import { parseGarms } from '../lambdas/utils/parseGarms';
-import { parseTDI } from '../lambdas/utils/parseTDI';
-import { PaymentMethodService } from '../transaction/payment-method.service';
-import { TransactionEntity } from '../transaction/entities';
+import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
+import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { validateOrReject, ValidationError } from 'class-validator';
+import { FileUploadedEntity } from './entities/file-uploaded.entity';
+import { Repository } from 'typeorm';
+import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
+import { CashDepositDTO, CashDepositsListDTO } from './dto/cash-deposit.dto';
 import {
   GarmsTransactionDTO,
   GarmsTransactionList,
 } from './dto/garms-transaction.dto';
-import { validateOrReject, ValidationError } from 'class-validator';
-import { TDI17Details, TDI34Details } from '../flat-files';
-import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
-import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { FileUploadedEntity } from './entities/file-uploaded.entity';
-import { Repository } from 'typeorm';
-import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
-import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
-import { CashDepositDTO, CashDepositsListDTO } from './dto/cash-deposit.dto';
 import { PosDepositDTO, PosDepositListDTO } from './dto/pos-deposit.dto';
+import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
+import { FileTypes, ParseArgsTDI } from '../constants';
+import { TDI17Details, TDI34Details } from '../flat-files';
+import { parseGarms } from '../lambdas/utils/parseGarms';
+import { parseTDI } from '../lambdas/utils/parseTDI';
+import { AppLogger } from '../logger/logger.service';
+import { TransactionEntity } from '../transaction/entities';
+import { SBCGarmsJson } from '../transaction/interface';
+import { PaymentMethodService } from '../transaction/payment-method.service';
 
 @Injectable()
 export class ParseService {

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -20,6 +20,8 @@ import { Repository } from 'typeorm';
 import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
 import { format } from 'date-fns';
 import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
+import { CashDepositDTO, CashDepositsListDTO } from './dto/cash-deposit.dto';
+import { PosDepositDTO, PosDepositListDTO } from './dto/pos-deposit.dto';
 
 @Injectable()
 export class ParseService {
@@ -62,7 +64,6 @@ export class ParseService {
     const garmsSalesDTO = garmsSales.map((t) => new GarmsTransactionDTO(t));
     const list = new GarmsTransactionList(garmsSalesDTO);
     try {
-      this.appLogger.log(list);
       await validateOrReject(list);
     } catch (e: any) {
       this.appLogger.error('ERROR');
@@ -91,6 +92,16 @@ export class ParseService {
     const cashDeposits = tdi17Details.map(
       (details) => new CashDepositEntity(details)
     );
+    const cashDepositsDto = cashDeposits.map((c) => new CashDepositDTO(c));
+    const list = new CashDepositsListDTO(cashDepositsDto);
+    try {
+      await validateOrReject(list);
+    } catch (e: any) {
+      this.appLogger.error('ERROR');
+      console.log(e[0]);
+      // We can use error.children.value
+      throw new Error('errrorr');
+    }
     return cashDeposits;
   }
 
@@ -112,19 +123,17 @@ export class ParseService {
     const posEntities = tdi34Details.map(
       (details) => new POSDepositEntity(details)
     );
+    const cashDepositsDto = posEntities.map((p) => new PosDepositDTO(p));
+    const list = new PosDepositListDTO(cashDepositsDto);
+    try {
+      await validateOrReject(list);
+    } catch (e: any) {
+      this.appLogger.error('ERROR');
+      console.log(e[0]);
+      // We can use error.children.value
+      throw new Error('errrorr');
+    }
     return posEntities;
-  }
-
-  async getFileUploadedForDate(date: Date): Promise<FileUploadedEntity | null> {
-    return null;
-    // return this.uploadedRepo.findOne({
-    //   where: {
-    //     dataDate: date,
-    //   },
-    // });
-    /*await this.uploadedRepo.createQueryBuilder('fileUploaded')
-      .andWhere('dataDate = :today', { today: format(date, 'yyyy-MM-dd') })
-      .getOne();*/
   }
 
   async saveFileUploaded(
@@ -171,7 +180,7 @@ export class ParseService {
       const daily = this.programDailyRepo.create(newDaily);
       return this.saveDaily(daily);
     } catch (e) {
-      console.log(e);
+      throw new Error('ERROR SAVING DAILY');
     }
   }
 

--- a/apps/backend/src/parse/ro/daily-alert.ro.ts
+++ b/apps/backend/src/parse/ro/daily-alert.ro.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class DailyAlertProgramRO {
+  @ApiProperty({
+    description: 'The program for this alert',
+    example: 'SBC',
+    required: true,
+  })
+  program: string;
+
+  @ApiProperty({
+    description: 'Successful daily upload',
+    example: false,
+    required: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Whether an alert was sent about this daily',
+    example: true,
+    required: true,
+  })
+  alerted: boolean;
+}
+
+export class DailyAlertRO {
+  @ApiProperty({
+    description: 'List of programs and alert status for the day',
+    required: true,
+  })
+  dailyAlertPrograms: DailyAlertProgramRO[];
+
+  @ApiProperty({
+    description: 'Date of daily',
+    required: true,
+  })
+  date: Date;
+}

--- a/apps/backend/src/s3-manager/s3-manager.service.ts
+++ b/apps/backend/src/s3-manager/s3-manager.service.ts
@@ -22,6 +22,13 @@ export class S3ManagerService {
     return response;
   }
 
+  async getObjectStream(bucket: string, key: string) {
+    const response = await this.s3
+      .getObject({ Bucket: bucket, Key: key })
+      .createReadStream();
+    return response;
+  }
+
   async putObject(bucket: string, key: string, body: Buffer) {
     const response = await this.s3
       .putObject({ Bucket: bucket, Key: key, Body: body })

--- a/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
+++ b/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
@@ -27,7 +27,7 @@ export class ArePaymentMethodsValid implements ValidatorConstraintInterface {
     }
 
     const paymentMethodSum = paymentMethods.reduce((sum, method) => {
-      return new Decimal(sum).plus(method.amount).toNumber();
+      return new Decimal(sum).plus(method.amount).toDecimalPlaces(2).toNumber();
     }, new Decimal(0).toNumber());
 
     if (sales.total_transaction_amount !== paymentMethodSum) {

--- a/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
+++ b/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
@@ -4,6 +4,7 @@ import {
   ValidationArguments,
   isArray,
 } from 'class-validator';
+import Decimal from 'decimal.js';
 import { PaymentDTO } from '../dto/payment.dto';
 import { GarmsTransactionDTO } from '../../parse/dto/garms-transaction.dto';
 
@@ -26,8 +27,8 @@ export class ArePaymentMethodsValid implements ValidatorConstraintInterface {
     }
 
     const paymentMethodSum = paymentMethods.reduce((sum, method) => {
-      return sum + method.amount;
-    }, 0);
+      return new Decimal(sum).plus(method.amount).toNumber();
+    }, new Decimal(0).toNumber());
 
     if (sales.total_transaction_amount !== paymentMethodSum) {
       this.errorMessage = `Sum Of Amounts by Payment Method does not equal Sale total.`;

--- a/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
+++ b/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
@@ -4,8 +4,8 @@ import {
   ValidationArguments,
   isArray,
 } from 'class-validator';
+import { GarmsTransactionDTO } from '../../parse/dto/garms-transaction.dto';
 import { PaymentDTO } from '../dto/payment.dto';
-import { TransactionDTO } from '../dto/transaction.dto';
 
 @ValidatorConstraint()
 export class ArePaymentMethodsValid implements ValidatorConstraintInterface {
@@ -18,7 +18,7 @@ export class ArePaymentMethodsValid implements ValidatorConstraintInterface {
     paymentMethods: PaymentDTO[],
     args: ValidationArguments
   ) {
-    const sales = args.object as TransactionDTO;
+    const sales = args.object as GarmsTransactionDTO;
 
     if (!isArray(paymentMethods)) {
       this.errorMessage = `Distributions must be an array`;

--- a/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
+++ b/apps/backend/src/transaction/decorators/arePaymentMethodsValid.ts
@@ -4,8 +4,8 @@ import {
   ValidationArguments,
   isArray,
 } from 'class-validator';
-import { GarmsTransactionDTO } from '../../parse/dto/garms-transaction.dto';
 import { PaymentDTO } from '../dto/payment.dto';
+import { GarmsTransactionDTO } from '../../parse/dto/garms-transaction.dto';
 
 @ValidatorConstraint()
 export class ArePaymentMethodsValid implements ValidatorConstraintInterface {

--- a/apps/backend/src/transaction/dto/payment.dto.ts
+++ b/apps/backend/src/transaction/dto/payment.dto.ts
@@ -78,7 +78,7 @@ export class PaymentDTO {
   @ApiProperty({ description: 'Payment Method', example: 'cash' })
   @IsString()
   @IsNotEmpty()
-  method!: string;
+  payment_method!: string;
 
   @ApiProperty({ description: 'Terminal', type: TerminalDTO })
   @IsNotEmpty()

--- a/apps/backend/src/transaction/dto/transaction.dto.ts
+++ b/apps/backend/src/transaction/dto/transaction.dto.ts
@@ -80,7 +80,7 @@ export class TransactionDTO {
   })
   @ArrayUnique(
     (o: PaymentDTO) => {
-      return o.method;
+      return o.payment_method;
     },
     { message: 'Payment Method items must be unique' }
   )

--- a/apps/backend/src/transaction/dto/transaction.dto.ts
+++ b/apps/backend/src/transaction/dto/transaction.dto.ts
@@ -19,6 +19,7 @@ import { SourceDTO } from './source.dto';
 /**
  * Potentially deprecated, but will likely still need some formatting
  * from here, such as what's the source and accounting objects
+ * [CCFCPM-460] - As work begins on API endpoints for adding transactions, we can work to combine the two dtos
  */
 export class TransactionDTO {
   @ApiProperty({

--- a/apps/backend/src/transaction/dto/transaction.dto.ts
+++ b/apps/backend/src/transaction/dto/transaction.dto.ts
@@ -16,6 +16,10 @@ import { AccountingDTO } from './accounting.dto';
 import { PaymentDTO } from './payment.dto';
 import { SourceDTO } from './source.dto';
 
+/**
+ * Potentially deprecated, but will likely still need some formatting
+ * from here, such as what's the source and accounting objects
+ */
 export class TransactionDTO {
   @ApiProperty({
     description: 'Unique id representing the transaction in the source system',

--- a/apps/backend/src/transaction/entities/transaction.entity.ts
+++ b/apps/backend/src/transaction/entities/transaction.entity.ts
@@ -1,4 +1,13 @@
-import { Relation, OneToMany, Entity, Column, PrimaryColumn } from 'typeorm';
+import {
+  Relation,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+  Entity,
+  Column,
+  PrimaryColumn,
+} from 'typeorm';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { PaymentEntity } from './payment.entity';
 import { Transaction } from '../interface/transaction.interface';
 
@@ -46,6 +55,10 @@ export class TransactionEntity {
     cascade: true,
   })
   payments: Relation<PaymentEntity[]>;
+
+  @ManyToOne(() => FileUploadedEntity, { nullable: true })
+  @JoinColumn({ name: 'file_uploaded' })
+  fileUploadedEntity?: FileUploadedEntity;
 
   constructor(transaction?: Partial<TransactionEntity>) {
     Object.assign(this, transaction);

--- a/apps/backend/src/transaction/entities/transaction.entity.ts
+++ b/apps/backend/src/transaction/entities/transaction.entity.ts
@@ -7,9 +7,9 @@ import {
   Column,
   PrimaryColumn,
 } from 'typeorm';
-import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 import { PaymentEntity } from './payment.entity';
 import { Transaction } from '../interface/transaction.interface';
+import { FileUploadedEntity } from '../../parse/entities/file-uploaded.entity';
 
 @Entity('transaction')
 export class TransactionEntity {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -35,6 +35,7 @@ services:
       - APP_PORT=3000
       - NODE_ENV=ci
       - RUNTIME_ENV=test
+      - API_URL={API_URL}
       - AWS_ACCESS_KEY_ID=pcc
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_DEFAULT_REGION=${AWS_REGION}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -35,7 +35,7 @@ services:
       - APP_PORT=3000
       - NODE_ENV=ci
       - RUNTIME_ENV=test
-      - API_URL={API_URL}
+      - API_URL=${API_URL}
       - AWS_ACCESS_KEY_ID=pcc
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_DEFAULT_REGION=${AWS_REGION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - APP_PORT=3000
       - NODE_ENV=local
       - RUNTIME_ENV=local
-      - API_URL={API_URL}
+      - API_URL=${API_URL}
       - AWS_ACCESS_KEY_ID=pcc
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_DEFAULT_REGION=${AWS_REGION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - APP_PORT=3000
       - NODE_ENV=local
       - RUNTIME_ENV=local
+      - API_URL={API_URL}
       - AWS_ACCESS_KEY_ID=pcc
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_DEFAULT_REGION=${AWS_REGION}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "dom"],
     "module": "commonjs",
     "target": "es2022",
     "declaration": true,


### PR DESCRIPTION
[CCFPCM-497](https://bcdevex.atlassian.net/browse/CCFPCM-497)

Note: I'm not quite sure why SQ is detecting so many duplicates on the migration file.
The GarmsTransaction duplication is a little bit by design. I think the TransactionDTO is partly deprecated, but need to have a discussion before removing it.

Objective: 
- The process goes:
    - Need to manually add rules for each program on what file names to expect
    - When the parser is run (manually for now), it creates a "daily" upload to denote the day's uploads
    - It uploads each file that needs it, the same as before
    - If there is a validation error, we (will eventually) send an alert for it, but for now we do an error log in the lambda
    - After all files are uploaded, it POSTs to the alert endpoint to see if it needs to send out an alert based on which files have been uploaded and if it has passed the retry threshold

Still to clean up before merging:
- A possible timezone bug when creating a new file past 5pm PST (creates the file for tomorrow I think)

Future PRs:
- Migration to move all the file names from transactions / deposits to the new file upload system, and check that new table instead
- Testing for Parse Service
- Very very proper error handling (this should probably be a ticket itself)

Problems that might warrant discussion:
- This is really only good if the parser is just run "for today". Doesn't take into account any past uploads, or what happens if the flow is blocked up.