### PR TITLE
[FIX] ingestion success logic can now be false

### DIFF
--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -245,6 +245,18 @@ export class ParseController {
    * Based on the daily program status, and which files are required by the rules
    * @returns Array of DailyAlertROs to determine which programs are successful and which programs have been alerted
    */
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        date: {
+          type: 'string',
+          nullable: false,
+          example: '2023-01-01',
+        },
+      },
+    },
+  })
   @Post('daily-upload/alert')
   async dailyUploadAlert(@Body() body: { date: Date }): Promise<DailyAlertRO> {
     const rules = await this.parseService.getAllRules();

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -214,6 +214,18 @@ export class ParseController {
    * Commence daily upload for a specific date for each program area we have in the rules
    * Called at the start of a parser lambda run
    */
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        date: {
+          type: 'string',
+          nullable: false,
+          example: '2023-01-01',
+        },
+      },
+    },
+  })
   @Post('daily-upload')
   async commenceDailyUpload(@Body() body: { date: string }): Promise<void> {
     const rules = await this.parseService.getAllRules();

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -48,19 +48,16 @@ export class ParseService {
     files: FileUploadedEntity[]
   ): boolean {
     const { cashChequesFilename, posFilename, transactionsFilename } = rule;
-    const hasTdi17 =
-      (cashChequesFilename &&
-        !files?.some((file) => file.sourceFileType === FileTypes.TDI17)) ||
-      true;
-    const hasTdi34 =
-      (posFilename &&
-        !files?.some((file) => file.sourceFileType === FileTypes.TDI34)) ||
-      true;
-    const hasTransactionFile =
-      (transactionsFilename &&
-        !files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES)) ||
-      true;
-    const success = !hasTdi17 || !hasTdi34 || !hasTransactionFile;
+    const hasTdi17 = !!cashChequesFilename
+      ? files?.some((file) => file.sourceFileType === FileTypes.TDI17)
+      : true;
+    const hasTdi34 = !!posFilename
+      ? files?.some((file) => file.sourceFileType === FileTypes.TDI34)
+      : true;
+    const hasTransactionFile = !!transactionsFilename
+      ? files?.some((file) => file.sourceFileType === FileTypes.SBC_SALES)
+      : true;
+    const success = hasTdi17 && hasTdi34 && hasTransactionFile;
     return success;
   }
 


### PR DESCRIPTION
[CCFPCM-497](https://bcdevex.atlassian.net/browse/CCFPCM-497)

Objective: 
The success handler was returning true when it shouldn't. This now does not default to that.
Also, some api body schemas
