### PR TITLE
[CCFPCM-525] reconcile only if there are valid files uploaded today

### DIFF
--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -1,5 +1,6 @@
 {
-  "period": { "from": "2023-01-01", "to": "2023-06-16" },
+  "period": { "from": "2023-06-20", "to": "2023-06-21" },
   "program": "SBC",
-  "location_ids": []
+  "location_ids": [],
+  "bypass_parse_validity": false
 }

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { format, parse, subBusinessDays } from 'date-fns';
+import { format, parse, subBusinessDays, differenceInDays } from 'date-fns';
 import { AppModule } from '../app.module';
 import { MatchStatus } from '../common/const';
 import { NormalizedLocation } from '../constants';
@@ -9,6 +9,7 @@ import { PosDepositService } from '../deposits/pos-deposit.service';
 import { LocationService } from '../location/location.service';
 import { CashExceptionsService } from '../reconciliation/cash-exceptions.service';
 import { CashReconciliationService } from '../reconciliation/cash-reconciliation.service';
+import { ParseService } from '../parse/parse.service';
 import { PosReconciliationService } from '../reconciliation/pos-reconciliation.service';
 import { ReconciliationConfigInput } from '../reconciliation/types';
 import { ReportingService } from '../reporting/reporting.service';
@@ -27,7 +28,25 @@ export const handler = async (event: ReconciliationConfigInput) => {
   const posDepositService = app.get(PosDepositService);
   const locationService = app.get(LocationService);
   const reportingService = app.get(ReportingService);
+  const parseService = app.get(ParseService);
   const appLogger = app.get(Logger);
+
+  // Prevent reconciler from running for a program if no valid files today
+  // FOR NOW: if the to date range is yesterday and no files have been uploaded today only
+  // This is because we still need to be able to reconcile in the past for testing purposes
+  const reconciliationDate = new Date(event.period.to);
+  if (differenceInDays(reconciliationDate, new Date()) <= 1) {
+    // Reconciliation was yesterday, so continue with logic
+    const rule = await parseService.getRulesForProgram(event.program);
+    if (!rule) {
+      throw new Error('No rule for this program');
+    }
+    const daily = await parseService.getDailyForRule(rule, new Date());
+    if (!daily?.success) {
+      throw new Error('There are still invalid files for thie date');
+    }
+  }
+
   // maxDate is the date we are reconciling until
   // We reconcile 1 business day behind, so the user should only be passing in "yesterday" as maxDate
   // We should also ensure sync (automated - should have all data by 11am PST) and parse have run before this function is called

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { format, parse, subBusinessDays, differenceInDays } from 'date-fns';
+import { format, parse, subBusinessDays } from 'date-fns';
 import { AppModule } from '../app.module';
 import { MatchStatus } from '../common/const';
 import { NormalizedLocation } from '../constants';
@@ -31,12 +31,9 @@ export const handler = async (event: ReconciliationConfigInput) => {
   const parseService = app.get(ParseService);
   const appLogger = app.get(Logger);
 
-  // Prevent reconciler from running for a program if no valid files today
-  // FOR NOW: if the to date range is yesterday and no files have been uploaded today only
-  // This is because we still need to be able to reconcile in the past for testing purposes
-  const reconciliationDate = new Date(event.period.to);
-  if (differenceInDays(reconciliationDate, new Date()) <= 1) {
-    // Reconciliation was yesterday, so continue with logic
+  console.log(event.bypass_parse_validity);
+  if (!event.bypass_parse_validity) {
+    // Prevent reconciler from running for a program if no valid files today
     const rule = await parseService.getRulesForProgram(event.program);
     if (!rule) {
       throw new Error('No rule for this program');

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -31,7 +31,6 @@ export const handler = async (event: ReconciliationConfigInput) => {
   const parseService = app.get(ParseService);
   const appLogger = app.get(Logger);
 
-  console.log(event.bypass_parse_validity);
   if (!event.bypass_parse_validity) {
     // Prevent reconciler from running for a program if no valid files today
     const rule = await parseService.getRulesForProgram(event.program);

--- a/apps/backend/src/reconciliation/types/interface.ts
+++ b/apps/backend/src/reconciliation/types/interface.ts
@@ -34,6 +34,7 @@ export interface ReconciliationConfigInput {
   };
   location_ids: number[] | [];
   program: Ministries;
+  bypass_parse_validity?: boolean;
 }
 
 export interface ReconciliationError {


### PR DESCRIPTION
[CCFPCM-525](https://bcdevex.atlassian.net/browse/CCFPCM-525)

Objective: 
As part of AC3 (though I might try to move that AC elsewhere), we want to prevent the reconciler from running if files haven't been uploaded today. Unfortunately, this is an issue if we're running the reconciler for different scenarios. For example, we haven't uploaded the files today yet, but we're testing the reconciler for the past.

One interesting thing. We can only run the reconciler with a max date of "yesterday". However, uploading files adds them in for "today", for data "yesterday". This will be addressed in future tickets, potentially [491](https://bcdevex.atlassian.net/browse/CCFPCM-491)

