### PR TITLE
[CHORE] Optimizing parsing by utilizing relation ids

### DIFF
--- a/apps/backend/src/deposits/entities/cash-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/cash-deposit.entity.ts
@@ -97,6 +97,9 @@ export class CashDepositEntity {
   @JoinColumn({ name: 'file_uploaded' })
   fileUploadedEntity?: FileUploadedEntity;
 
+  @Column({ name: 'file_uploaded', nullable: true })
+  fileUploadedEntityId?: string;
+
   constructor(data?: TDI17Details) {
     Object.assign(this, data?.resource);
   }

--- a/apps/backend/src/deposits/entities/pos-deposit.entity.ts
+++ b/apps/backend/src/deposits/entities/pos-deposit.entity.ts
@@ -84,6 +84,9 @@ export class POSDepositEntity {
   @JoinColumn({ name: 'file_uploaded' })
   fileUploadedEntity?: FileUploadedEntity;
 
+  @Column({ name: 'file_uploaded', nullable: true })
+  fileUploadedEntityId?: string;
+
   @OneToOne(
     () => PaymentEntity,
     (payment: PaymentEntity) => payment.pos_deposit_match,

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -349,7 +349,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
         await transactionService.saveTransactions(
           garmsSales.map((sale) => ({
             ...sale,
-            fileUploadedEntity: fileToSave,
+            fileUploadedEntityId: fileToSave.id,
           }))
         );
       }
@@ -371,7 +371,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
         await cashDepositService.saveCashDepositEntities(
           cashDeposits.map((deposit) => ({
             ...deposit,
-            fileUploadedEntity: fileToSave,
+            fileUploadedEntityId: fileToSave.id,
           }))
         );
       }
@@ -393,7 +393,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
         await posDepositService.savePOSDepositEntities(
           posEntities.map((deposit) => ({
             ...deposit,
-            fileUploadedEntity: fileToSave,
+            fileUploadedEntityId: fileToSave.id,
             timestamp: deposit.timestamp,
           }))
         );

--- a/apps/backend/src/transaction/entities/transaction.entity.ts
+++ b/apps/backend/src/transaction/entities/transaction.entity.ts
@@ -60,6 +60,9 @@ export class TransactionEntity {
   @JoinColumn({ name: 'file_uploaded' })
   fileUploadedEntity?: FileUploadedEntity;
 
+  @Column({ name: 'file_uploaded', nullable: true })
+  fileUploadedEntityId?: string;
+
   constructor(transaction?: Partial<TransactionEntity>) {
     Object.assign(this, transaction);
   }


### PR DESCRIPTION
Objective: 
This optimizes the parsing for the whole dataset. In my machine, it took under 12 minutes until July. May still need a longer term solution if this builds up to, say, a year's worth of data.

The validation itself turned out to not be the issue, but the fact that relationships in TypeORM can be non performant when you're talking about thousands of entries at once.

Utilizes this TypeORM trick 
https://github.com/typeorm/typeorm/blob/master/docs/relations-faq.md#how-to-use-relation-id-without-joining-relation
