### PR TITLE
[CCFPCM-577] Require IMDSv2 for bastion host config

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -77,8 +77,8 @@ resource "aws_instance" "bastion_instance" {
   subnet_id                   = tolist(data.aws_subnets.app.ids)[0]
   user_data                   = file("scripts/user-data.sh")
   
-  metadata_options = {
-    http_tokens = required
+  metadata_options {
+    http_tokens = "required"
   }
 
   root_block_device {

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -76,6 +76,10 @@ resource "aws_instance" "bastion_instance" {
   associate_public_ip_address = "false"
   subnet_id                   = tolist(data.aws_subnets.app.ids)[0]
   user_data                   = file("scripts/user-data.sh")
+  
+  metadata_options = {
+    http_tokens = required
+  }
 
   root_block_device {
     delete_on_termination = "true"
@@ -83,7 +87,6 @@ resource "aws_instance" "bastion_instance" {
     volume_size           = var.root_block_device.size
     volume_type           = var.root_block_device.type
   }
-
 
   tags = {
     Name = "${local.namespace}-bastion"


### PR DESCRIPTION
[CCFPCM-577](https://bcdevex.atlassian.net/browse/CCFPCM-577)

Objective: 
- Addresses the high sev alert in Security Hub
- Must specify this metadata to limit IMDS to only support v2, not also v1 (default setting allows both)
- Note I haven't applied this change yet :) I decided it would be best to keep scope small for this fix, but open to hearing we should address other things as part of this same PR
