### PR TITLE
[CCFPCM-491] required files, alert destinations

### DIFF
--- a/apps/backend/src/database/datasource.ts
+++ b/apps/backend/src/database/datasource.ts
@@ -6,6 +6,7 @@ import { LocationEntity } from '../location/entities';
 import { FileIngestionRulesEntity } from '../parse/entities/file-ingestion-rules.entity';
 import { FileUploadedEntity } from '../parse/entities/file-uploaded.entity';
 import { ProgramDailyUploadEntity } from '../parse/entities/program-daily-upload.entity';
+import { ProgramRequiredFileEntity } from '../parse/entities/program-required-file.entity';
 import {
   TransactionEntity,
   PaymentEntity,
@@ -29,6 +30,7 @@ export default new DataSource({
     FileUploadedEntity,
     ProgramDailyUploadEntity,
     FileIngestionRulesEntity,
+    ProgramRequiredFileEntity,
   ],
   migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
   synchronize: false,

--- a/apps/backend/src/database/datasource.ts
+++ b/apps/backend/src/database/datasource.ts
@@ -7,6 +7,7 @@ import { FileIngestionRulesEntity } from '../parse/entities/file-ingestion-rules
 import { FileUploadedEntity } from '../parse/entities/file-uploaded.entity';
 import { ProgramDailyUploadEntity } from '../parse/entities/program-daily-upload.entity';
 import { ProgramRequiredFileEntity } from '../parse/entities/program-required-file.entity';
+import { AlertDestinationEntity } from '../notification/entities/alert-destination.entity';
 import {
   TransactionEntity,
   PaymentEntity,
@@ -31,6 +32,7 @@ export default new DataSource({
     ProgramDailyUploadEntity,
     FileIngestionRulesEntity,
     ProgramRequiredFileEntity,
+    AlertDestinationEntity,
   ],
   migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
   synchronize: false,

--- a/apps/backend/src/database/migrations/1689666205003-required-files-migration.ts
+++ b/apps/backend/src/database/migrations/1689666205003-required-files-migration.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1689666205003 implements MigrationInterface {
+  name = 'rquired-files-migration1689635953535';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "program_required_file" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "filename" character varying NOT NULL, "file_type" character varying NOT NULL, "rule_id" uuid, CONSTRAINT "PK_6f2e3955cb6b01f1e2ff4e124bf" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" DROP COLUMN "cash_cheques_filename"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" DROP COLUMN "transactions_filename"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" DROP COLUMN "pos_filename"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "program_required_file" ADD CONSTRAINT "FK_accca5c473c9b3b0a0f777aaae8" FOREIGN KEY ("rule_id") REFERENCES "file_ingestion_rules"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(`
+      INSERT INTO program_required_file (filename, file_type, rule_id) VALUES
+      ('F08TDI17', 'TDI17', (SELECT id FROM file_ingestion_rules WHERE program = 'SBC')),
+      ('F08TDI34', 'TDI34', (SELECT id FROM file_ingestion_rules WHERE program = 'SBC')),
+      ('SBC_SALES', 'SBC_SALES', (SELECT id FROM file_ingestion_rules WHERE program = 'SBC')),
+      ('F08TDI17', 'TDI17', (SELECT id FROM file_ingestion_rules WHERE program = 'LABOUR')),
+      ('F08TDI34', 'TDI34', (SELECT id FROM file_ingestion_rules WHERE program = 'LABOUR'));
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "program_required_file" DROP CONSTRAINT "FK_accca5c473c9b3b0a0f777aaae8"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" ADD "pos_filename" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" ADD "transactions_filename" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" ADD "cash_cheques_filename" character varying`
+    );
+    await queryRunner.query(`DROP TABLE "program_required_file"`);
+    await queryRunner.query(
+      `UPDATE file_ingestion_rules SET cash_cheques_filename='F08TDI17', pos_filename='F08TDI34', transactions_filename='SBC_SALES' WHERE program = 'SBC';`
+    );
+    await queryRunner.query(
+      `UPDATE file_ingestion_rules SET cash_cheques_filename='F08TDI17', pos_filename='F08TDI34'  WHERE program = 'LABOUR';`
+    );
+  }
+}

--- a/apps/backend/src/database/migrations/1689667429932-alert-destination-migration.ts
+++ b/apps/backend/src/database/migrations/1689667429932-alert-destination-migration.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1689667429932 implements MigrationInterface {
+  name = 'alert-destination-migration1689667429932';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "alert_destination" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_date" TIMESTAMP NOT NULL DEFAULT now(), "all_alerts" boolean NOT NULL DEFAULT false, "destination" character varying NOT NULL, "rule_id" uuid, "required_file_id" uuid, CONSTRAINT "PK_71f411b94831464a936bf1a3fca" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_destination" ADD CONSTRAINT "FK_1fe83748519ab39a7ce4ce1846d" FOREIGN KEY ("rule_id") REFERENCES "file_ingestion_rules"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_destination" ADD CONSTRAINT "FK_544c33cad3b1b1e062968523a77" FOREIGN KEY ("required_file_id") REFERENCES "program_required_file"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alert_destination" DROP CONSTRAINT "FK_544c33cad3b1b1e062968523a77"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_destination" DROP CONSTRAINT "FK_1fe83748519ab39a7ce4ce1846d"`
+    );
+    await queryRunner.query(`DROP TABLE "alert_destination"`);
+  }
+}

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -120,10 +120,11 @@ export const handler = async (event?: unknown, _context?: Context) => {
         if (!alert.success) {
           const incompleteString = `Daily Upload for ${alert.program} is incomplete.`;
           errors.push(incompleteString);
-          !alert.files.hasTdi17 && errors.push('Missing a TDI17 file.');
-          !alert.files.hasTdi34 && errors.push('Missing a TDI34 file.');
-          !alert.files.hasTransactionFile &&
-            errors.push('Missing a Transactions file');
+          alert.missingFiles.forEach((file) => {
+            errors.push(
+              `Missing a ${file.fileType} file - needs file name "${file.filename}"`
+            );
+          });
         }
 
         appLogger.log(errors.join(' '));
@@ -187,23 +188,12 @@ export const handler = async (event?: unknown, _context?: Context) => {
       }
 
       const fileType = (() => {
-        if (
-          currentRule.cashChequesFilename &&
-          filename.includes(currentRule.cashChequesFilename)
-        ) {
-          return FileTypes.TDI17;
-        }
-        if (
-          currentRule.posFilename &&
-          filename.includes(currentRule.posFilename)
-        ) {
-          return FileTypes.TDI34;
-        }
-        if (
-          currentRule.transactionsFilename &&
-          filename.includes(currentRule.transactionsFilename)
-        ) {
-          return FileTypes.SBC_SALES;
+        const requiredFiles = currentRule?.requiredFiles;
+        const requiredFile = requiredFiles?.find((rf) =>
+          filename.includes(rf.filename)
+        );
+        if (!!requiredFile) {
+          return requiredFile.fileType;
         }
         throw new Error('Unknown file type: ' + filename);
       })();
@@ -271,7 +261,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
           program: rule.program,
           success: true,
           alerted: false,
-          files: { hasTdi17: true, hasTdi34: true, hasTransactionFile: true },
+          missingFiles: [],
         });
         continue;
       }
@@ -288,7 +278,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
           program: rule.program,
           success: true,
           alerted: false,
-          files: { hasTdi17: true, hasTdi34: true, hasTransactionFile: true },
+          missingFiles: [],
         });
       } else {
         let alerted = false;
@@ -304,11 +294,7 @@ export const handler = async (event?: unknown, _context?: Context) => {
           program: rule.program,
           success: false,
           alerted,
-          files: {
-            hasTdi17: successStatus.hasTdi17,
-            hasTdi34: successStatus.hasTdi34,
-            hasTransactionFile: successStatus.hasTransactionFile,
-          },
+          missingFiles: successStatus.missingFiles,
         });
       }
     }

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -140,6 +140,11 @@ export const handler = async (event?: unknown, _context?: Context) => {
             errors.join(' ')
           );
         }
+        mailService.sendEmailAlert(
+          MAIL_TEMPLATE_ENUM.FILES_MISSING_ALERT,
+          '',
+          ''
+        );
       }
     } catch (err) {
       appLogger.error(err);

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -142,8 +142,8 @@ export const handler = async (event?: unknown, _context?: Context) => {
         }
         mailService.sendEmailAlert(
           MAIL_TEMPLATE_ENUM.FILES_MISSING_ALERT,
-          '',
-          ''
+          process.env.MAIL_SERVICE_DEFAULT_TO_EMAIL || '',
+          errors.join(' ')
         );
       }
     } catch (err) {

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -140,11 +140,6 @@ export const handler = async (event?: unknown, _context?: Context) => {
             errors.join(' ')
           );
         }
-        mailService.sendEmailAlert(
-          MAIL_TEMPLATE_ENUM.FILES_MISSING_ALERT,
-          process.env.MAIL_SERVICE_DEFAULT_TO_EMAIL || '',
-          errors.join(' ')
-        );
       }
     } catch (err) {
       appLogger.error(err);

--- a/apps/backend/src/notification/entities/alert-destination.entity.ts
+++ b/apps/backend/src/notification/entities/alert-destination.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  Entity,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { FileIngestionRulesEntity } from '../../parse/entities/file-ingestion-rules.entity';
+import { ProgramRequiredFileEntity } from '../../parse/entities/program-required-file.entity';
+
+@Entity('alert_destination')
+export class AlertDestinationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn({ name: 'created_date' })
+  createdDate: Date;
+
+  /**
+   * Only one of the next three must be truthy
+   */
+
+  // Send all alerts to this destination
+  @Column('boolean', { default: false, name: 'all_alerts' })
+  allAlerts: boolean;
+
+  // Send all alerts for a certain program / rule to this destination
+  @ManyToOne(() => FileIngestionRulesEntity, { nullable: true })
+  @JoinColumn({ name: 'rule_id' })
+  rule?: FileIngestionRulesEntity;
+
+  // Send all alerts for a specific file type / data source to this destination
+  @ManyToOne(() => ProgramRequiredFileEntity, { nullable: true })
+  @JoinColumn({ name: 'required_file_id' })
+  requiredFile: ProgramRequiredFileEntity;
+
+  // Typically email; can eventually be a phone number if necessary
+  @Column({ nullable: false })
+  destination: string;
+}

--- a/apps/backend/src/notification/mail.service.ts
+++ b/apps/backend/src/notification/mail.service.ts
@@ -24,9 +24,15 @@ export class MailService {
     });
   }
 
+  /**
+   * getAlertDestinations - Gets list of destinations / emails to send alerts to
+   * @param program Program name
+   * @param filenames All the filenames that have issues
+   * @returns <string[]> list of destinatinos
+   */
   public async getAlertDestinations(
     program: string,
-    missingFilenames: string[]
+    filenames: string[]
   ): Promise<string[]> {
     const allDestinations = await this.destinationRepo.find({
       relations: {
@@ -39,11 +45,17 @@ export class MailService {
         (destination) =>
           destination.allAlerts === true ||
           destination.rule?.program === program ||
-          missingFilenames.includes(destination.requiredFile.filename)
+          filenames.includes(destination.requiredFile.filename)
       )
       .map((destination) => destination.destination);
   }
 
+  /**
+   * sendEmailAlert - Sends a single email to a single destination
+   * @param template From list of template enums
+   * @param toEmail Destination email
+   * @param message Customization message
+   */
   public async sendEmailAlert(
     template: MAIL_TEMPLATE_ENUM,
     toEmail: string,

--- a/apps/backend/src/notification/notification.module.ts
+++ b/apps/backend/src/notification/notification.module.ts
@@ -1,7 +1,10 @@
 import { Logger, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MailService } from './mail.service';
+import { AlertDestinationEntity } from './entities/alert-destination.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([AlertDestinationEntity])],
   providers: [MailService, Logger],
   exports: [MailService],
 })

--- a/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
+++ b/apps/backend/src/parse/entities/file-ingestion-rules.entity.ts
@@ -1,4 +1,5 @@
-import { Column, PrimaryGeneratedColumn, Entity } from 'typeorm';
+import { Column, OneToMany, PrimaryGeneratedColumn, Entity } from 'typeorm';
+import { ProgramRequiredFileEntity } from './program-required-file.entity';
 
 @Entity('file_ingestion_rules')
 export class FileIngestionRulesEntity {
@@ -8,14 +9,8 @@ export class FileIngestionRulesEntity {
   @Column()
   program: string;
 
-  @Column({ nullable: true, name: 'cash_cheques_filename' })
-  cashChequesFilename?: string; // TDI17
-
-  @Column({ nullable: true, name: 'pos_filename' })
-  posFilename?: string; // TDI34
-
-  @Column({ nullable: true, name: 'transactions_filename' })
-  transactionsFilename?: string;
+  @OneToMany(() => ProgramRequiredFileEntity, (file) => file.rule)
+  requiredFiles: ProgramRequiredFileEntity[];
 
   // Number of retries before we send an alert
   @Column({ type: 'int4', default: 0 })

--- a/apps/backend/src/parse/entities/program-required-file.entity.ts
+++ b/apps/backend/src/parse/entities/program-required-file.entity.ts
@@ -1,0 +1,30 @@
+import { FileTypes } from '../../constants';
+import {
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  Entity,
+  ManyToOne,
+  JoinColumn,
+  Relation,
+} from 'typeorm';
+import { FileIngestionRulesEntity } from './file-ingestion-rules.entity';
+
+@Entity('program_required_file')
+export class ProgramRequiredFileEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @Column()
+  filename: string;
+
+  @Column({ enum: FileTypes, name: 'file_type' })
+  fileType: FileTypes;
+
+  @ManyToOne(() => FileIngestionRulesEntity, (rule) => rule.requiredFiles)
+  @JoinColumn({ name: 'rule_id' })
+  rule: Relation<FileIngestionRulesEntity>;
+}

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -277,7 +277,7 @@ export class ParseController {
           program: rule.program,
           success: true,
           alerted: false,
-          files: { hasTdi17: true, hasTdi34: true, hasTransactionFile: true },
+          missingFiles: [],
         });
         continue;
       }
@@ -294,12 +294,11 @@ export class ParseController {
           program: rule.program,
           success: true,
           alerted: false,
-          files: { hasTdi17: true, hasTdi34: true, hasTransactionFile: true },
+          missingFiles: [],
         });
       } else {
         let alerted = false;
         if (daily.retries >= rule.retries) {
-          // TODO CCFPCM-441
           alerted = true;
         }
         await this.parseService.saveDaily({
@@ -310,11 +309,7 @@ export class ParseController {
           program: rule.program,
           success: false,
           alerted,
-          files: {
-            hasTdi17: successStatus.hasTdi17,
-            hasTdi34: successStatus.hasTdi34,
-            hasTransactionFile: successStatus.hasTransactionFile,
-          },
+          missingFiles: successStatus.missingFiles,
         });
       }
     }

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FileIngestionRulesEntity } from './entities/file-ingestion-rules.entity';
 import { FileUploadedEntity } from './entities/file-uploaded.entity';
 import { ProgramDailyUploadEntity } from './entities/program-daily-upload.entity';
+import { ProgramRequiredFileEntity } from './entities/program-required-file.entity';
 import { ParseController } from './parse.controller';
 import { ParseService } from './parse.service';
 import { DepositModule } from '../deposits/deposit.module';
@@ -16,6 +17,7 @@ import { TransactionModule } from '../transaction/transaction.module';
       FileUploadedEntity,
       FileIngestionRulesEntity,
       ProgramDailyUploadEntity,
+      ProgramRequiredFileEntity,
     ]),
   ],
   controllers: [ParseController],

--- a/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
+++ b/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
@@ -4,16 +4,10 @@ import { FileIngestionRulesEntity } from '../../../src/parse/entities/file-inges
 export class FileIngestionRulesMock extends FileIngestionRulesEntity {
   constructor(
     program: string,
-    cashChequesFilename?: string | undefined,
-    posFilename?: string | undefined,
-    transactionsFilename?: string | undefined
   ) {
     super();
     this.id = faker.datatype.uuid();
     this.program = program;
     this.retries = faker.datatype.number({ min: 0, max: 3 });
-    this.cashChequesFilename = cashChequesFilename;
-    this.posFilename = posFilename;
-    this.transactionsFilename = transactionsFilename;
   }
 }

--- a/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
+++ b/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
@@ -1,13 +1,19 @@
 import { faker } from '@faker-js/faker';
 import { FileIngestionRulesEntity } from '../../../src/parse/entities/file-ingestion-rules.entity';
+import { ProgramRequiredFileMock } from './required_file_mock';
+import { FileTypes } from '../../../src/constants';
 
 export class FileIngestionRulesMock extends FileIngestionRulesEntity {
-  constructor(
-    program: string,
-  ) {
+  constructor(program: string) {
     super();
     this.id = faker.datatype.uuid();
     this.program = program;
     this.retries = faker.datatype.number({ min: 0, max: 3 });
+    this.requiredFiles = [];
+  }
+
+  public assignRequiredFile(filename: string, fileType: FileTypes) {
+    const requiredFile = new ProgramRequiredFileMock(filename, fileType, this);
+    this.requiredFiles.push(requiredFile);
   }
 }

--- a/apps/backend/test/mocks/classes/required_file_mock.ts
+++ b/apps/backend/test/mocks/classes/required_file_mock.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker';
+import { ProgramRequiredFileEntity } from '../../../src/parse/entities/program-required-file.entity';
+import { FileTypes } from '../../../src/constants';
+import { FileIngestionRulesEntity } from '../../../src/parse/entities/file-ingestion-rules.entity';
+
+export class ProgramRequiredFileMock extends ProgramRequiredFileEntity {
+  constructor(
+    filename: string,
+    fileType: FileTypes,
+    rule: FileIngestionRulesEntity
+  ) {
+    super();
+    this.id = faker.datatype.uuid();
+    this.createdAt = faker.date.past();
+    this.fileType = fileType;
+    this.filename = filename;
+    this.rule = rule;
+  }
+}

--- a/apps/backend/test/unit/parsing/parse-service.spec.ts
+++ b/apps/backend/test/unit/parsing/parse-service.spec.ts
@@ -13,6 +13,8 @@ import { ParseService } from '../../../src/parse/parse.service';
 import { PaymentMethodService } from '../../../src/transaction/payment-method.service';
 import { FileIngestionRulesMock } from '../../mocks/classes/file_ingestion_rules_mock';
 import { FileUploadedMock } from '../../mocks/classes/file_upload_mock';
+import { ProgramRequiredFileMock } from '../../mocks/classes/required_file_mock';
+import { ProgramRequiredFileEntity } from '../../../src/parse/entities/program-required-file.entity';
 
 describe('ParseService', () => {
   let service: ParseService;
@@ -41,6 +43,10 @@ describe('ParseService', () => {
           provide: getRepositoryToken(FileUploadedEntity),
           useValue: createMock<Repository<FileUploadedEntity>>(),
         },
+        {
+          provide: getRepositoryToken(ProgramRequiredFileEntity),
+          useValue: createMock<Repository<ProgramRequiredFileEntity>>(),
+        },
       ],
     }).compile();
 
@@ -53,12 +59,10 @@ describe('ParseService', () => {
 
   describe('determines whether a daily upload is successful', () => {
     it('should be successful if all files are present', () => {
-      const rule = new FileIngestionRulesMock(
-        'SBC',
-        'bcm/PROD_SBC_F08TDI17_20230309.DAT',
-        'bcm/PROD_SBC_F08TDI34_20230309.DAT',
-        'sbc/SBC_SALES_2023_03_08_23_17_53.JSON'
-      );
+      const rule = new FileIngestionRulesMock('SBC');
+      rule.assignRequiredFile('F08TDI17', FileTypes.TDI17);
+      rule.assignRequiredFile('F08TDI34', FileTypes.TDI34);
+      rule.assignRequiredFile('SBC_SALES', FileTypes.SBC_SALES);
       const tdi17 = new FileUploadedMock(
         FileTypes.TDI17,
         'bcm/PROD_SBC_F08TDI17_20230309.DAT'
@@ -80,12 +84,9 @@ describe('ParseService', () => {
     });
 
     it('should be successful if all required files are present - not necessarily all 3', () => {
-      const rule = new FileIngestionRulesMock(
-        'SBC',
-        'bcm/PROD_SBC_F08TDI17_20230309.DAT',
-        'bcm/PROD_SBC_F08TDI34_20230309.DAT',
-        undefined
-      );
+      const rule = new FileIngestionRulesMock('SBC');
+      rule.assignRequiredFile('F08TDI17', FileTypes.TDI17);
+      rule.assignRequiredFile('F08TDI34', FileTypes.TDI34);
       const tdi17 = new FileUploadedMock(
         FileTypes.TDI17,
         'bcm/PROD_SBC_F08TDI17_20230309.DAT'
@@ -99,12 +100,10 @@ describe('ParseService', () => {
     });
 
     it('should fail if one or more of the required files are not present', () => {
-      const rule = new FileIngestionRulesMock(
-        'SBC',
-        'bcm/PROD_SBC_F08TDI17_20230309.DAT',
-        'bcm/PROD_SBC_F08TDI34_20230309.DAT',
-        undefined
-      );
+      const rule = new FileIngestionRulesMock('SBC');
+      rule.assignRequiredFile('F08TDI17', FileTypes.TDI17);
+      rule.assignRequiredFile('F08TDI34', FileTypes.TDI34);
+      rule.assignRequiredFile('SBC_SALES', FileTypes.SBC_SALES);
       const tdi17 = new FileUploadedMock(
         FileTypes.TDI17,
         'bcm/PROD_SBC_F08TDI17_20230309.DAT'


### PR DESCRIPTION
[CCFPCM-491](https://bcdevex.atlassian.net/browse/CCFPCM-491)

Objective: 
This addressed AC#1, AC#2 for 491. Using the database, we can configure:
- Filenames in a more fine-grained way, so that if, for example, a program requires two different TDI17s, we can account for that
- Alerts in a more fine-grained way, so that we can configure who gets what email