### PR TITLE
[CHORE] fix pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd ./apps/backend && yarn run lint-staged
+cd apps/backend && yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "build:backend": "yarn workspace @payment/backend build",
     "compodoc": "yarn workspace @payment/backend docs",
     "test": "echo 'Running tests' && wsrun --parallel --exclude-missing test",
-    "eslint-nibble": "echo 'Checking code style' && yarn workspace @payment/backend nibble"
+    "eslint-nibble": "echo 'Checking code style' && yarn workspace @payment/backend nibble",
+    "postinstall": "husky install"
   },
   "devDependencies": {
     "eslint": "8.32.0",
     "eslint-config-prettier": "8.6.0",
     "eslint-nibble": "8.1.0",
     "eslint-plugin-prettier": "4.2.1",
+    "husky": "8.0.0",
     "npm-run-all": "4.1.5",
     "wsrun": "5.2.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,6 +7090,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:8.0.0":
+  version: 8.0.0
+  resolution: "husky@npm:8.0.0"
+  bin:
+    husky: lib/bin.js
+  checksum: b6b842abdd1bbc9322ad0c2003471fa35f94c9c01fccef3a6b5262f53e3f1bde1d78787f8a96ed8ef8a15ab3a7d56c83f576afd1cf7618588df77940044081df
+  languageName: node
+  linkType: hard
+
 "i18next@npm:^21.6.11":
   version: 21.10.0
   resolution: "i18next@npm:21.10.0"
@@ -9857,6 +9866,7 @@ __metadata:
     eslint-config-prettier: 8.6.0
     eslint-nibble: 8.1.0
     eslint-plugin-prettier: 4.2.1
+    husky: 8.0.0
     npm-run-all: 4.1.5
     wsrun: 5.2.4
   languageName: unknown


### PR DESCRIPTION
[CHORE](https://bcdevex.atlassian.net/browse/CHORE)

Objective: 

- pre-commit hook was not running (runs lint-staged on commit)
- to enable, run `yarn` followed by `yarn husky install` 
- pre-commit hook can be overridden by using the `-n` flag when committing 

example console printout:
![Screenshot 2023-07-23 at 10 20 08 PM](https://github.com/bcgov/PaymentCommonComponent/assets/78890675/3fc23e53-eef2-40f1-9e7c-49f0c523f6aa)
