### PR TITLE
[CCFPCM-0575] reconciliation to trigger report

### DIFF
--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -1,6 +1,5 @@
 {
-  "period": { "from": "2023-01-01", "to": "2023-07-11" },
+  "period": { "from": "2023-01-01", "to": "2023-01-31" },
   "program": "SBC",
-  "location_ids": [],
   "bypass_parse_validity": true
 }

--- a/apps/backend/src/lambdas/reconcile.ts
+++ b/apps/backend/src/lambdas/reconcile.ts
@@ -186,5 +186,5 @@ export const handler = async (event: ReconciliationConfigInput) => {
   console.table(cashReport);
 
   //TODO use this only for local and set the reconciliation lambda destination to trigger the report
-  await reportHandler(event);
+  isLocal && (await reportHandler(event));
 };

--- a/apps/backend/src/reconciliation/cash-exceptions.service.ts
+++ b/apps/backend/src/reconciliation/cash-exceptions.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
-import { parse } from 'date-fns';
 import { MatchStatus } from '../common/const';
 import { Ministries, NormalizedLocation } from '../constants';
 import { CashDepositService } from '../deposits/cash-deposit.service';
@@ -26,7 +25,7 @@ export class CashExceptionsService {
     location: NormalizedLocation,
     program: Ministries,
     exceptionsDate: string,
-    currentDate: string
+    currentDate: Date
   ): Promise<{ payments: number; deposits: number }> {
     const payments: PaymentEntity[] =
       await this.paymentService.findPaymentsExceptions(
@@ -47,7 +46,7 @@ export class CashExceptionsService {
           ...itm,
           timestamp: itm.timestamp,
           status: MatchStatus.EXCEPTION,
-          reconciled_on: parse(currentDate, 'yyyy-MM-dd', new Date()),
+          reconciled_on: currentDate,
         }))
       );
 
@@ -56,7 +55,7 @@ export class CashExceptionsService {
         deposits.map((itm) => ({
           ...itm,
           status: MatchStatus.EXCEPTION,
-          reconciled_on: parse(currentDate, 'yyyy-MM-dd', new Date()),
+          reconciled_on: currentDate,
         }))
       );
 

--- a/apps/backend/src/reconciliation/cash-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/cash-reconciliation.service.ts
@@ -114,9 +114,9 @@ export class CashReconciliationService {
   public async reconcileCash(
     location: NormalizedLocation,
     program: Ministries,
-    dateRange: DateRange
+    dateRange: DateRange,
+    currentDate: Date
   ): Promise<unknown> {
-    const currentDate = new Date();
     const pendingDeposits: CashDepositEntity[] =
       await this.cashDepositService.findCashDepositsByDate(
         program,

--- a/apps/backend/src/reconciliation/types/interface.ts
+++ b/apps/backend/src/reconciliation/types/interface.ts
@@ -28,12 +28,11 @@ export interface ReconciliationConfig {
 }
 
 export interface ReconciliationConfigInput {
+  program: Ministries;
   period: {
     from: string;
     to: string;
   };
-  location_ids: number[] | [];
-  program: Ministries;
   bypass_parse_validity?: boolean;
 }
 

--- a/apps/backend/src/reporting/interfaces.ts
+++ b/apps/backend/src/reporting/interfaces.ts
@@ -1,19 +1,7 @@
 import * as Excel from 'exceljs';
-import { Ministries } from '../constants';
+import { ReconciliationConfigInput } from '../reconciliation/types';
 
-export interface ReportConfig {
-  program: Ministries;
-  locations: number[];
-  period: {
-    from: string;
-    to: string;
-  };
-  exceptions: {
-    generate: boolean;
-    send: boolean;
-  };
-  reports: boolean;
-}
+export type ReportConfig = ReconciliationConfigInput;
 
 export interface DailySummary {
   values: {


### PR DESCRIPTION
[CCFPCM-0575](https://bcdevex.atlassian.net/browse/CCFPCM-0575)

Objective: 
- Reconciliation Lambda to trigger report output
- TODO: set the daily file check lambda to trigger the reconciliation once daily per LoB (if all files present, otherwise, alert)
- TODO: move this outside of the lambda function and use the destination to trigger the lambda instead
- **note:** the reconciled on, in progress on, and uploaded on dates are still a bit messed up. We will need to use only the realtime dates once automation is in place, but if we run a batch reconciliation for a specific date and then try to generate the report it will break, as the report will include all items reconciled on that date (so if you reconcile the entire dataset in one go you will be generating a report for the full dataset)