### PR TITLE
[CCFPCM-610] batch-reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ mail_default_to = ""
 sns_reconciler_topic="$(SNS_RECONCILER_RESULTS_TOPIC)"
 sns_parser_topic="$(SNS_PARSER_RESULTS_TOPIC)"
 sns_batch_reconcile_topic="$(SNS_BATCH_RECONCILE_TOPIC)"
-disable_automated_recon="$(DISABLE_AUTOMATED_RECONCILIATION)"
+disable_automated_reconciliation="$(DISABLE_AUTOMATED_RECONCILIATION)"
 endef
 export TFVARS_DATA
 

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ be-logs:
 # Local
 # ===================================
 batch-reconcile: 
-	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/lambdas/batch-run.ts").handler($(BATCH_JSON))'
+	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/lambdas/batch-reconcile.ts").handler($(BATCH_JSON))'
 
 parse:
 	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/lambdas/parser.ts").handler($(PARSER_JSON))'

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ mail_default_to = ""
 sns_reconciler_topic="$(SNS_RECONCILER_RESULTS_TOPIC)"
 sns_parser_topic="$(SNS_PARSER_RESULTS_TOPIC)"
 sns_batch_reconcile_topic="$(SNS_BATCH_RECONCILE_TOPIC)"
+disable_automated_recon="$(DISABLE_AUTOMATED_RECONCILIATION)"
 endef
 export TFVARS_DATA
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ mail_base_url = "$(MAIL_SERVICE_BASE_URL)"
 mail_default_to = ""
 sns_reconciler_topic="$(SNS_RECONCILER_RESULTS_TOPIC)"
 sns_parser_topic="$(SNS_PARSER_RESULTS_TOPIC)"
+sns_batch_reconcile_topic="$(SNS_BATCH_RECONCILE_TOPIC)"
 endef
 export TFVARS_DATA
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ export GIT_LOCAL_BRANCH := $(or $(GIT_LOCAL_BRANCH),dev)
 REPORT_JSON:=$(shell cat ./apps/backend/fixtures/lambda/report.json | jq '.' -c)
 RECONCILE_JSON:=$(shell cat ./apps/backend/fixtures/lambda/reconcile.json | jq '.' -c)
 PARSER_JSON:=$(shell cat ./apps/backend/fixtures/lambda/parser.json | jq '.' -c)
+BATCH_JSON:=$(shell cat ./apps/backend/fixtures/lambda/batch.json | jq '.' -c)
 
 # Terraform variables
 TERRAFORM_DIR = terraform
@@ -275,6 +276,8 @@ be-logs:
 # ===================================
 # Local
 # ===================================
+batch-reconcile: 
+	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/lambdas/batch-run.ts").handler($(BATCH_JSON))'
 
 parse:
 	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/lambdas/parser.ts").handler($(PARSER_JSON))'

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -67,12 +67,28 @@ Refer [here](./docs/access.md)
 - configuration options can be found [here](https://compodoc.app/guides/options.html)
 
 ### Reconciliation
-
+##### How To Run On local:
 - Make sure the project is up and running by using the docker make commands
 - Make sure you have completed the steps above
-- Edit the `apps/backend/fixtures/reconcile.json` file to specifiy config
-- Run (from root) `make reconcile`
-- Refer [here](./docs/reconciliation.md)
+- In order to run the reconciliation on the entire dataset as though it had run daily we should use the file metadata and filename (for SBC json files) to extract the date and run reconciliation based on that date.
+- Parsing, reconciliation and reports are all automated by default. When you run sync/parse the entire dataset will be reconciled (job is >1 hr but should only need to run once per env unless you drop your db)
+  - run: ‘make drop', ‘make migrations-run’, ‘make sync’, 'make parse’
+- Reconciliation can be run manually (only runs for the specified dates, does not batch):
+  - run: 'make reconcile' and update reconcile.json
+- Automated reconciliation can be turned off:
+  - set DISABLE_AUTOMATED_RECONCILIATION=true
+- Automated reports can be set to false in the reconciliation input:
+  - "generateReport": false
+- Reports can be generated manually
+  - run 'make report' after updating report.json
+- If you do not want to re-parse your data, or you only want to batch reconcile some of the data:
+  - run 'make batch-reconcile' (uses default inputs for Jan 1 to current date, these can be overridden in batch.json)
+
+##### How It Runs On Dev/Test:
+
+- Whenever data is dropped into the S3 bucket, either manually or via the sync job, it will be parsed and reconciled and will generate a report
+
+- On dev, if you want to use the manual overrides you should drop your test data into the db and allow it to be parsed. Then, run the queries to reset the status to the pre-reconciled state. Now you can use the test tab in the lambdas to run manually.
 
 ### Reporting
 

--- a/apps/backend/fixtures/lambda/batch.json
+++ b/apps/backend/fixtures/lambda/batch.json
@@ -1,0 +1,8 @@
+{
+  "period": {
+    "from": "",
+    "to": ""
+  },
+  "program": "SBC",
+  "generateReport": true
+}

--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -3,13 +3,12 @@
     {
       "Sns": {
         "Message": {
-          "reconciliationEventOverride": true,
-          "byPassFileValidity": false,
           "period": {
             "from": "2023-01-01",
             "to": "2023-02-03"
           },
-          "program": "SBC"
+          "program": "SBC", 
+          "generateReport": false
         }
       }
     }

--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -4,11 +4,12 @@
       "Sns": {
         "Message": {
           "period": {
-            "from": "",
-            "to": ""
+            "from": "2023-01-01",
+            "to": "2023-01-02"
           },
           "program": "SBC", 
-          "generateReport": false
+          "generateReport": true, 
+          "byPassFileValidity": false
         }
       }
     }

--- a/apps/backend/fixtures/lambda/reconcile.json
+++ b/apps/backend/fixtures/lambda/reconcile.json
@@ -4,8 +4,8 @@
       "Sns": {
         "Message": {
           "period": {
-            "from": "2023-01-01",
-            "to": "2023-02-03"
+            "from": "",
+            "to": ""
           },
           "program": "SBC", 
           "generateReport": false

--- a/apps/backend/fixtures/lambda/report.json
+++ b/apps/backend/fixtures/lambda/report.json
@@ -2,7 +2,13 @@
   "Records": [
     {
       "Sns": {
-        "Message": {}
+        "Message": {
+          "period": {
+            "from": "2023-01-01",
+            "to": "2023-02-03"
+          },
+          "program": "SBC"
+        }
       }
     }
   ]

--- a/apps/backend/src/lambdas/batch-reconcile.ts
+++ b/apps/backend/src/lambdas/batch-reconcile.ts
@@ -6,7 +6,7 @@ import { HandlerEvent } from './interface';
 import { handler as reconcile } from './reconcile';
 import { AppModule } from '../app.module';
 import { AppLogger } from '../logger/logger.service';
-import { ReportingService } from '../reporting/reporting.service';
+
 import { SnsManagerService } from '../sns-manager/sns-manager.service';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -14,8 +14,9 @@ export const handler = async (event: HandlerEvent, _context?: Context) => {
   const app = await NestFactory.createApplicationContext(AppModule);
   const appLogger = app.get(AppLogger);
   const snsService = app.get(SnsManagerService);
+
+  appLogger.log({ event, _context }, 'BATCH RECONCILIATION EVENT');
   const isLocal = process.env.RUNTIME_ENV === 'local';
-  const reportingService = app.get(ReportingService);
 
   const listOfDays = eachDayOfInterval({
     start: event.period.from
@@ -24,47 +25,21 @@ export const handler = async (event: HandlerEvent, _context?: Context) => {
     end: event.period.to ? new Date(event.period.to) : new Date(),
   });
 
-  appLogger.log({ event, _context }, 'BATCH RECONCILIATION EVENT');
+  const messages = listOfDays.map((date) => ({
+    period: {
+      from: format(subBusinessDays(date, 31), 'yyyy-MM-dd'),
+      to: format(date, 'yyyy-MM-dd'),
+    },
+    program: event.program,
+    generateReport: event.generateReport,
+  }));
 
-  for (const date of listOfDays) {
-    appLogger.log(
-      {
-        message: `Processing Reconciliation For: ${format(date, 'yyyy-MM-dd')}`,
-      },
-      'BATCH RECONCILIATION EVENT'
-    );
-
-    try {
-      const reconciliationParams = {
-        period: {
-          from: format(subBusinessDays(date, 31), 'yyyy-MM-dd'),
-          to: format(date, 'yyyy-MM-dd'),
-        },
-        program: event.program,
-        generateReport: event.generateReport,
-      };
-      if (!isLocal) {
-        const topic = process.env.SNS_PARSER_RESULTS_TOPIC;
-        await snsService.publish(topic, JSON.stringify(reconciliationParams));
-      } else {
-        await reconcile(generateLocalSNSMessage(reconciliationParams));
-      }
-    } catch (err) {
-      appLogger.error(err);
-      return { success: false, message: `${err}` };
+  for (const message of messages) {
+    if (!isLocal) {
+      const topic = process.env.SNS_PARSER_RESULTS_TOPIC;
+      await snsService.publish(topic, JSON.stringify(message));
+    } else {
+      await reconcile(generateLocalSNSMessage(message));
     }
   }
-  const showConsoleReport = async () => {
-    const posReport = await reportingService.reportPosMatchSummaryByDate();
-    const statusReport = await reportingService.getStatusReport();
-    appLogger.log('\n\n=========POS Summary Report: =========\n');
-    console.table(posReport);
-    const { paymentStatus, depositStatus } = statusReport;
-    console.table(paymentStatus);
-    console.table(depositStatus);
-    const cashReport = await reportingService.reportCashMatchSummaryByDate();
-    appLogger.log('\n\n=========Cash Summary Report: =========\n');
-    console.table(cashReport);
-  };
-  isLocal && (await showConsoleReport());
 };

--- a/apps/backend/src/lambdas/batch-reconcile.ts
+++ b/apps/backend/src/lambdas/batch-reconcile.ts
@@ -32,6 +32,7 @@ export const handler = async (event: HandlerEvent, _context?: Context) => {
     },
     program: event.program,
     generateReport: event.generateReport,
+    byPassFileValidity: true,
   }));
 
   for (const message of messages) {

--- a/apps/backend/src/lambdas/batch-reconcile.ts
+++ b/apps/backend/src/lambdas/batch-reconcile.ts
@@ -1,11 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { Context } from 'aws-lambda';
-import { SNS } from 'aws-sdk';
-import {
-  eachDayOfInterval,
-  format,
-  subBusinessDays,
-} from 'date-fns';
+import { eachDayOfInterval, format, subBusinessDays } from 'date-fns';
 import { generateLocalSNSMessage } from './helpers';
 import { HandlerEvent } from './interface';
 import { handler as reconcile } from './reconcile';
@@ -50,14 +45,7 @@ export const handler = async (event: HandlerEvent, _context?: Context) => {
       };
       if (!isLocal) {
         const topic = process.env.SNS_PARSER_RESULTS_TOPIC;
-        const response: SNS.Types.PublishResponse = await snsService.publish(
-          topic,
-          JSON.stringify(reconciliationParams)
-        );
-        return {
-          success: true,
-          response,
-        };
+        await snsService.publish(topic, JSON.stringify(reconciliationParams));
       } else {
         await reconcile(generateLocalSNSMessage(reconciliationParams));
       }

--- a/apps/backend/src/lambdas/batch-run.ts
+++ b/apps/backend/src/lambdas/batch-run.ts
@@ -1,0 +1,118 @@
+import { NestFactory } from '@nestjs/core';
+import { Context } from 'aws-lambda';
+import { SNS } from 'aws-sdk';
+import {
+  eachDayOfInterval,
+  format,
+  isSaturday,
+  isSunday,
+  subBusinessDays,
+} from 'date-fns';
+import { HandlerEvent } from './interface';
+import { handler as reconcile } from './reconcile';
+import { AppModule } from '../app.module';
+import { AppLogger } from '../logger/logger.service';
+import { ReportingService } from '../reporting/reporting.service';
+import { SnsManagerService } from '../sns-manager/sns-manager.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const handler = async (event: HandlerEvent, _context?: Context) => {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const appLogger = app.get(AppLogger);
+  const snsService = app.get(SnsManagerService);
+  const isLocal = process.env.RUNTIME_ENV === 'local';
+  const reportingService = app.get(ReportingService);
+
+  const listOfDays = eachDayOfInterval({
+    start: event.period.from
+      ? new Date(event.period.from)
+      : new Date('2023-01-01'),
+    end: event.period.to ? new Date(event.period.to) : new Date(),
+  });
+
+  appLogger.log({ event, _context }, 'BATCH RECONCILIATION EVENT');
+
+  for (const date of listOfDays) {
+    if (!isSaturday(date) && !isSunday(date)) {
+      appLogger.log(
+        {
+          message: `Processing Reconciliation For: ${format(
+            date,
+            'yyyy-MM-dd'
+          )}`,
+        },
+        'BATCH RECONCILIATION EVENT'
+      );
+
+      try {
+        const reconciliationInputs = {
+          period: {
+            from: format(subBusinessDays(date, 31), 'yyyy-MM-dd'),
+            to: format(date, 'yyyy-MM-dd'),
+          },
+          program: event.program,
+          generateReport: event.generateReport,
+        };
+        if (!isLocal) {
+          const SNS_PARSER_RESULTS_TOPIC = process.env.SNS_PARSER_RESULTS_TOPIC;
+          const response: SNS.Types.PublishResponse = await snsService.publish(
+            SNS_PARSER_RESULTS_TOPIC || '',
+            JSON.stringify(reconciliationInputs)
+          );
+          return {
+            success: true,
+            response,
+          };
+        } else {
+          await reconcile({
+            Records: [
+              {
+                EventSource: 'aws:sns',
+                EventVersion: '1.0',
+                EventSubscriptionArn: 'arn:aws:sns:EXAMPLE',
+                Sns: {
+                  SignatureVersion: '1',
+                  Timestamp: '1970-01-01T00:00:00.000Z',
+                  Signature: 'EXAMPLE',
+                  SigningCertUrl: 'EXAMPLE',
+                  MessageId: '95df01b4-ee98-5cb9-9903-4c221d41eb5e',
+                  TopicArn: 'arn:aws:sns:us-east-2:123456789012:MyTopic',
+                  MessageAttributes: {},
+                  Type: 'Notification',
+                  UnsubscribeUrl: 'EXAMPLE',
+                  Subject: 'TestInvoke',
+                  Message: JSON.stringify(reconciliationInputs),
+                },
+              },
+            ],
+          });
+        }
+      } catch (err) {
+        appLogger.error(err);
+        return { success: false, message: `${err}` };
+      }
+    }
+    appLogger.log(
+      {
+        message: `Skipping Reconciliation: ${format(
+          date,
+          'yyyy-MM-dd'
+        )} because it is a weekend.`,
+      },
+      { context: 'RECONCILIATION EVENT' }
+    );
+  }
+  const showConsoleReport = async () => {
+    const posReport = await reportingService.reportPosMatchSummaryByDate();
+    const statusReport = await reportingService.getStatusReport();
+    appLogger.log('\n\n=========POS Summary Report: =========\n');
+    console.table(posReport);
+    const { paymentStatus, depositStatus } = statusReport;
+    console.table(paymentStatus);
+    console.table(depositStatus);
+    const cashReport = await reportingService.reportCashMatchSummaryByDate();
+    appLogger.log('\n\n=========Cash Summary Report: =========\n');
+    console.table(cashReport);
+  };
+  isLocal && (await showConsoleReport());
+};

--- a/apps/backend/src/lambdas/const.ts
+++ b/apps/backend/src/lambdas/const.ts
@@ -1,3 +1,0 @@
-export const reg = new RegExp(
-  /sbc\/\SBC_SALES_(20)\d{2}_(0[1-9]|1[0-2])_(0[1-9]|[12][0-9]|3[01])_\d{2}_\d{2}_\d{2}.JSON/gi
-);

--- a/apps/backend/src/lambdas/helpers.ts
+++ b/apps/backend/src/lambdas/helpers.ts
@@ -4,7 +4,7 @@
  */
 export const extractDateFromTXNFileName = (fileName: string): string => {
   const name = fileName.split('/')[1].split('.')[0];
-  const date = name.replace('SBC_SALES_', '').replace(/[_]/gi, '-');
+  const date = name.replace('SBC_SALES_', '').replace(/_/gi, '-');
   return date.slice(0, 10);
 };
 /**
@@ -15,7 +15,7 @@ export const extractDateFromTXNFileName = (fileName: string): string => {
  */
 export const validateSbcGarmsFileName = (filename: string): boolean => {
   try {
-    return /sbc\/\SBC_SALES_(20)\d{2}_(0[1-9]|1[0-2])_(0[1-9]|[12][0-9]|3[01])_\d{2}_\d{2}_\d{2}.JSON/gi.test(
+    return /sbc\/\SBC_SALES_(20)\d{2}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_\d{2}_\d{2}_\d{2}.JSON/gi.test(
       filename
     );
   } catch (err) {

--- a/apps/backend/src/lambdas/interface.ts
+++ b/apps/backend/src/lambdas/interface.ts
@@ -18,3 +18,14 @@ export interface SNSRecord {
 export interface EventSuccessSNSMessage {
   Records: SNSRecord[];
 }
+
+export interface HandlerEvent {
+  reconciliationEventOverride: boolean;
+  byPassFileValidity: boolean;
+  period: {
+    from: string;
+    to: string;
+  };
+  program: Ministries;
+  generateReport: boolean;
+}

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { S3Event, Context } from 'aws-lambda';
 import { SNS } from 'aws-sdk';
-import { subBusinessDays } from 'date-fns';
+import { format, subBusinessDays } from 'date-fns';
 import { AppModule } from '../app.module';
 import { Ministries } from '../constants';
 import { AppLogger } from '../logger/logger.service';
@@ -26,8 +26,8 @@ export const handler = async (event: S3Event, _context?: Context) => {
           generateReport: true,
           program: Ministries.SBC,
           period: {
-            to: new Date(),
-            from: subBusinessDays(new Date(), 31),
+            to: format(new Date(), 'yyyy-MM-dd'),
+            from: format(subBusinessDays(new Date(), 31), 'yyyy-MM-dd'),
           },
         })
       );

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -1,41 +1,17 @@
 import { NestFactory } from '@nestjs/core';
 import { S3Event, Context } from 'aws-lambda';
-import { SNS } from 'aws-sdk';
-import { format, subBusinessDays } from 'date-fns';
 import { AppModule } from '../app.module';
-import { Ministries } from '../constants';
 import { AppLogger } from '../logger/logger.service';
 import { ParseService } from '../parse/parse.service';
-import { SnsManagerService } from '../sns-manager/sns-manager.service';
 
 export const handler = async (event: S3Event, _context?: Context) => {
   const app = await NestFactory.createApplicationContext(AppModule);
   const appLogger = app.get(AppLogger);
   const parseService = app.get(ParseService);
-  const snsService = app.get(SnsManagerService);
-  const isLocal = process.env.RUNTIME_ENV === 'local';
   appLogger.log({ event, _context }, 'PARSE EVENT');
 
   try {
     await parseService.processAllFiles(event);
-    if (!isLocal) {
-      const topic = process.env.SNS_PARSER_RESULTS_TOPIC;
-      const response: SNS.Types.PublishResponse = await snsService.publish(
-        topic,
-        JSON.stringify({
-          generateReport: true,
-          program: Ministries.SBC,
-          period: {
-            to: format(new Date(), 'yyyy-MM-dd'),
-            from: format(subBusinessDays(new Date(), 31), 'yyyy-MM-dd'),
-          },
-        })
-      );
-      return {
-        success: true,
-        response,
-      };
-    }
   } catch (err) {
     appLogger.error(err);
     return { success: false, message: `${err}` };

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -9,9 +9,15 @@ export const handler = async (event: S3Event, _context?: Context) => {
   const appLogger = app.get(AppLogger);
   const parseService = app.get(ParseService);
   appLogger.log({ event, _context }, 'PARSE EVENT');
-
+  const automatedReconciliationEnabled =
+    !process.env.DISABLE_LOCAL_RECONCILE;
+  const isLocal: boolean = process.env.RUNTIME_ENV === 'local';
   try {
-    await parseService.processAllFiles(event);
+    await parseService.processAllFiles(
+      event,
+      isLocal,
+      automatedReconciliationEnabled
+    );
   } catch (err) {
     appLogger.error(err);
     return { success: false, message: `${err}` };

--- a/apps/backend/src/parse/parse.module.ts
+++ b/apps/backend/src/parse/parse.module.ts
@@ -6,6 +6,7 @@ import { ParseService } from './parse.service';
 import { DepositModule } from '../deposits/deposit.module';
 import { NotificationModule } from '../notification/notification.module';
 import { S3ManagerModule } from '../s3-manager/s3-manager.module';
+import { SnsManagerModule } from '../sns-manager/sns-manager.module';
 import { TransactionModule } from '../transaction/transaction.module';
 
 @Module({
@@ -16,6 +17,7 @@ import { TransactionModule } from '../transaction/transaction.module';
     DepositModule,
     TransactionModule,
     NotificationModule,
+    SnsManagerModule,
     TypeOrmModule.forFeature([FileUploadedEntity]),
   ],
   controllers: [ParseController],

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -8,7 +8,6 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { S3Event, S3EventRecord } from 'aws-lambda';
-import { SNS } from 'aws-sdk';
 import { validateOrReject, ValidationError } from 'class-validator';
 import { format, parse, subBusinessDays } from 'date-fns';
 import { Repository } from 'typeorm';
@@ -311,9 +310,7 @@ export class ParseService {
           const fileDate = file?.dailyUpload?.dailyDate;
           if (!isLocal) {
             const topic = process.env.SNS_PARSER_RESULTS_TOPIC;
-            type NewType = SNS.Types.PublishResponse;
-
-            const response: NewType = await this.snsService.publish(
+            const response = await this.snsService.publish(
               topic,
               JSON.stringify({
                 generateReport: true,

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -19,7 +19,7 @@ import {
 } from './dto/garms-transaction.dto';
 import { PosDepositDTO, PosDepositListDTO } from './dto/pos-deposit.dto';
 import { FileUploadedEntity } from './entities/file-uploaded.entity';
-import { FileTypes, Ministries, ParseArgsTDI } from '../constants';
+import { FileTypes, Ministries } from '../constants';
 import { CashDepositService } from '../deposits/cash-deposit.service';
 import { CashDepositEntity } from '../deposits/entities/cash-deposit.entity';
 import { POSDepositEntity } from '../deposits/entities/pos-deposit.entity';
@@ -101,31 +101,6 @@ export class ParseService {
         : '';
     }
     return errorMessage;
-  }
-
-  /**
-   * Function used by `flat-file` endpoint to parse TDI
-   */
-  async readAndParseFile({
-    type,
-    fileName,
-    program,
-    fileContents,
-  }: ParseArgsTDI): Promise<unknown> {
-    try {
-      const header = parseTDIHeader(type, fileContents);
-      //TODO upload? Or parse to the db?
-      return parseTDI({
-        type,
-        fileName,
-        program,
-        fileContents: Buffer.from(fileContents || '').toString(),
-        header,
-      });
-    } catch (err) {
-      this.appLogger.error(err, 'Error parsing file');
-      throw err;
-    }
   }
 
   /**
@@ -353,7 +328,6 @@ export class ParseService {
         await this.alertService.getAllRules();
       // for every ruleset, check if the FileInjestionRuleEntity matches the prgram from the filename
       //TODO change this to not use the filename to validate (ie use the bucket key instead after the file directory is changed TBD)
-
       const ministry = (() => {
         for (const rule of rules) {
           if (filename.includes(rule.program)) {
@@ -390,16 +364,6 @@ export class ParseService {
           fileType,
           Buffer.from(file.Body?.toString() || '')
         );
-        // const formData = new FormData();
-        // formData.append('file', Readable.from(file), filename);
-        // formData.append('fileName', filename);
-        // formData.append('fileType', fileType);
-        // formData.append('program', ministry);
-        // await axiosInstance.post('/v1/parse/upload-file', formData, {
-        //   headers: {
-        //     ...formData.getHeaders(),
-        //   },
-        // });
       } catch (err) {
         this.appLogger.log('\n\n=========Errors with File Upload: =========\n');
         this.appLogger.error(`Error with uploading file ${filename}`);

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -305,14 +305,14 @@ export class ParseService {
       // Parse & Save only files that have not been parsed before
       for (const filename of finalParseList) {
         this.appLogger.log(`Parsing ${filename}..`);
-        const isLocal = (process.env.RUNTIME_ENV = 'local');
+        const isLocal = process.env.RUNTIME_ENV === 'local';
 
         if (filename) {
           const file = await this.parseFileFromS3(filename);
           const fileDate = file?.dailyUpload?.dailyDate;
           if (!isLocal) {
             this.appLogger.log(
-              'Publiching SNS to reconcile',
+              'Publishing SNS to reconcile',
               ParseService.name
             );
             const topic = process.env.SNS_PARSER_RESULTS_TOPIC;

--- a/apps/backend/src/reconciliation/cash-reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/cash-reconciliation.service.ts
@@ -79,10 +79,6 @@ export class CashReconciliationService {
     for (const [dindex, deposit] of deposits.entries()) {
       for (const [pindex, payment] of aggregatedCashPayments.entries()) {
         if (this.checkMatch(payment, deposit)) {
-          this.appLogger.log(
-            `MATCHED PAYMENT: ${payment.amount} TO DEPOSIT: ${deposit.deposit_amt_cdn}`,
-            CashReconciliationService.name
-          );
           aggregatedCashPayments[pindex].status = MatchStatus.MATCH;
           deposits[dindex].status = MatchStatus.MATCH;
           matches.push({
@@ -132,20 +128,11 @@ export class CashReconciliationService {
       );
     if (pendingDeposits.length === 0 || aggregatedCashPayments.length === 0) {
       this.appLogger.log(
-        'No pending payments / deposits found',
+        'SKIPPING - No pending payments / deposits found',
         CashReconciliationService.name
       );
       return;
     }
-
-    this.appLogger.log(
-      `${aggregatedCashPayments.length} aggregated payments pending reconciliation`,
-      CashReconciliationService.name
-    );
-    this.appLogger.log(
-      `${pendingDeposits?.length} deposits pending reconciliation`,
-      CashReconciliationService.name
-    );
 
     const matches = this.matchPaymentsToDeposits(
       aggregatedCashPayments.filter((itm) =>

--- a/apps/backend/src/reporting/interfaces.ts
+++ b/apps/backend/src/reporting/interfaces.ts
@@ -1,7 +1,4 @@
 import * as Excel from 'exceljs';
-import { ReconciliationMessage } from '../lambdas/interface';
-
-export type ReportConfig = ReconciliationMessage;
 
 export interface DailySummary {
   values: {

--- a/apps/backend/test/unit/parsing/parse-service.spec.ts
+++ b/apps/backend/test/unit/parsing/parse-service.spec.ts
@@ -17,6 +17,7 @@ import { FileUploadedEntity } from '../../../src/parse/entities/file-uploaded.en
 import { ProgramRequiredFileEntity } from '../../../src/parse/entities/program-required-file.entity';
 import { ParseService } from '../../../src/parse/parse.service';
 import { S3ManagerService } from '../../../src/s3-manager/s3-manager.service';
+import { SnsManagerService } from '../../../src/sns-manager/sns-manager.service';
 import { PaymentMethodService } from '../../../src/transaction/payment-method.service';
 import { PaymentService } from '../../../src/transaction/payment.service';
 import { TransactionService } from '../../../src/transaction/transaction.service';
@@ -35,6 +36,10 @@ describe('ParseService', () => {
         {
           provide: S3ManagerService,
           useValue: createMock<S3ManagerService>(),
+        },
+        {
+          provide: SnsManagerService,
+          useValue: createMock<SnsManagerService>(),
         },
         {
           provide: PaymentMethodService,

--- a/terraform/lambda_batch_reconciler.tf
+++ b/terraform/lambda_batch_reconciler.tf
@@ -31,14 +31,14 @@ resource "aws_lambda_function" "batch_reconciler" {
     }
   }
 
-#   lifecycle {
-#     ignore_changes = [
-#       # Ignore changes to tags, e.g. because a management agent
-#       # updates these based on some ruleset managed elsewhere.
-#       filename,
-#       source_code_hash,
-#     ]
-#   }
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags, e.g. because a management agent
+      # updates these based on some ruleset managed elsewhere.
+      filename,
+      source_code_hash,
+    ]
+  }
 }
 
 resource "aws_lambda_function_event_invoke_config" "batch_reconciler_event" {

--- a/terraform/lambda_batch_reconciler.tf
+++ b/terraform/lambda_batch_reconciler.tf
@@ -1,0 +1,55 @@
+resource "aws_lambda_function" "batch_reconciler" {
+  description                    = "Manual Batch Reconciliation function ${local.namespace}"
+  function_name                  = "batch_reconciler"
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "nodejs18.x"
+  filename                       = "build/empty_lambda.zip"
+  source_code_hash               = filebase64sha256("build/empty_lambda.zip")
+  handler                        = "src/lambdas/batch-reconcile.handler"
+  memory_size                    = 1024
+  timeout                        = 900
+  reserved_concurrent_executions = 1
+
+  vpc_config {
+    security_group_ids = [data.aws_security_group.app.id]
+    subnet_ids         = data.aws_subnets.app.ids
+  }
+
+  environment {
+    variables = {
+      NODE_ENV                      = "production"
+      RUNTIME_ENV                   = var.target_env
+      DB_USER                       = var.db_username
+      DB_PASSWORD                   = data.aws_ssm_parameter.postgres_password.value
+      DB_HOST                       = aws_rds_cluster.pgsql.endpoint
+      DB_NAME                       = aws_rds_cluster.pgsql.database_name
+      MAIL_SERVICE_KEY              = data.aws_ssm_parameter.gcnotify_key.value
+      MAIL_SERVICE_BASE_URL         = var.mail_base_url
+      MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
+      SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
+      SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic      
+    }
+  }
+
+#   lifecycle {
+#     ignore_changes = [
+#       # Ignore changes to tags, e.g. because a management agent
+#       # updates these based on some ruleset managed elsewhere.
+#       filename,
+#       source_code_hash,
+#     ]
+#   }
+}
+
+resource "aws_lambda_function_event_invoke_config" "batch_reconciler_event" {
+  function_name = aws_lambda_function.batch_reconciler.function_name
+
+  destination_config {
+    on_success {
+      destination = aws_sns_topic.parser_results.arn
+    }
+    on_failure {
+      destination = aws_sns_topic.parser_results.arn
+    }
+  }
+}

--- a/terraform/lambda_batch_reconciler.tf
+++ b/terraform/lambda_batch_reconciler.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "batch_reconciler" {
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
       SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic      
+      SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
     }
   }
 
@@ -46,10 +47,10 @@ resource "aws_lambda_function_event_invoke_config" "batch_reconciler_event" {
 
   destination_config {
     on_success {
-      destination = aws_sns_topic.parser_results.arn
+      destination = aws_sns_topic.batch_reconcile.arn
     }
     on_failure {
-      destination = aws_sns_topic.parser_results.arn
+      destination = aws_sns_topic.batch_reconcile.arn
     }
   }
 }

--- a/terraform/lambda_batch_reconciler.tf
+++ b/terraform/lambda_batch_reconciler.tf
@@ -27,8 +27,9 @@ resource "aws_lambda_function" "batch_reconciler" {
       MAIL_SERVICE_BASE_URL         = var.mail_base_url
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
-      SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic      
+      SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic
       SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
+      DISABLE_AUTOMATED_RECONCILIATION = var.disable_automated_reconciliation
     }
   }
 
@@ -39,18 +40,5 @@ resource "aws_lambda_function" "batch_reconciler" {
       filename,
       source_code_hash,
     ]
-  }
-}
-
-resource "aws_lambda_function_event_invoke_config" "batch_reconciler_event" {
-  function_name = aws_lambda_function.batch_reconciler.function_name
-
-  destination_config {
-    on_success {
-      destination = aws_sns_topic.batch_reconcile.arn
-    }
-    on_failure {
-      destination = aws_sns_topic.batch_reconcile.arn
-    }
   }
 }

--- a/terraform/lambda_dailyfilecheck.tf
+++ b/terraform/lambda_dailyfilecheck.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "daily-alert" {
   runtime                        = "nodejs18.x"
   filename                       = "build/empty_lambda.zip"
   source_code_hash               = filebase64sha256("build/empty_lambda.zip")
-  handler                        = "src/lambdas/empty_lambda.handler"
+  handler                        = "src/lambdas/dailyfilecheck.handler"
   memory_size                    = 1024
   timeout                        = 600
   reserved_concurrent_executions = 1

--- a/terraform/lambda_dailyfilecheck.tf
+++ b/terraform/lambda_dailyfilecheck.tf
@@ -1,11 +1,11 @@
 resource "aws_lambda_function" "daily-alert" {
   description                    = "Daily alert function ${local.namespace}"
-  function_name                  = "dailyFileCheck-${local.namespace}"
+  function_name                  = "dailyFileCheck"
   role                           = aws_iam_role.lambda.arn
   runtime                        = "nodejs18.x"
   filename                       = "build/empty_lambda.zip"
   source_code_hash               = filebase64sha256("build/empty_lambda.zip")
-  handler                        = "src/lambdas/dailyfilecheck.handler"
+  handler                        = "src/lambdas/empty_lambda.handler"
   memory_size                    = 1024
   timeout                        = 600
   reserved_concurrent_executions = 1

--- a/terraform/lambda_parser.tf
+++ b/terraform/lambda_parser.tf
@@ -29,6 +29,8 @@ resource "aws_lambda_function" "parser" {
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
       SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic
+      SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
+      DISABLE_AUTOMATED_RECONCILIATION = var.disable_automated_reconciliation
     }
   }
 

--- a/terraform/lambda_parser.tf
+++ b/terraform/lambda_parser.tf
@@ -58,19 +58,6 @@ resource "aws_lambda_permission" "trigger-parse" {
   source_arn = "arn:aws:s3:::${aws_s3_bucket.sftp_storage.id}"
 }
 
-resource "aws_lambda_function_event_invoke_config" "parser_event" {
-  function_name = aws_lambda_function.parser.function_name
-
-  destination_config {
-    on_success {
-      destination = aws_sns_topic.parser_results.arn
-    }
-    on_failure {
-      destination = aws_sns_topic.parser_results.arn
-    }
-  }
-}
-
 output "arn" {
   value = "${aws_lambda_function.parser.arn}"
 }

--- a/terraform/lambda_reconciler.tf
+++ b/terraform/lambda_reconciler.tf
@@ -27,8 +27,9 @@ resource "aws_lambda_function" "reconciler" {
       MAIL_SERVICE_BASE_URL         = var.mail_base_url
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
-      SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic      
+      SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic
       SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
+      DISABLE_AUTOMATED_RECONCILIATION = var.disable_automated_reconciliation
     }
   }
 

--- a/terraform/lambda_reconciler.tf
+++ b/terraform/lambda_reconciler.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "reconciler" {
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
       SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic      
+      SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
     }
   }
 

--- a/terraform/lambda_reporting.tf
+++ b/terraform/lambda_reporting.tf
@@ -28,6 +28,8 @@ resource "aws_lambda_function" "reports" {
       MAIL_SERVICE_DEFAULT_TO_EMAIL = var.mail_default_to
       SNS_PARSER_RESULTS_TOPIC      = var.sns_parser_topic
       SNS_RECONCILER_RESULTS_TOPIC  = var.sns_reconciler_topic
+      SNS_BATCH_RECONCILE_TOPIC     = var.sns_batch_reconcile_topic
+      DISABLE_AUTOMATED_RECONCILIATION = var.disable_automated_reconciliation
     }
   }
 

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -33,3 +33,13 @@ resource "aws_lambda_permission" "reconciler_sns_permission" {
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.parser_results.arn
 }
+
+resource "aws_sns_topic" "batch_reconcile" {
+    name = "batch-reconcile-topic"
+}
+
+resource "aws_sns_topic_subscription" "batch_reconcile_target" {
+  topic_arn = aws_sns_topic.batch_reconcile.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.reconciler.arn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,6 +24,8 @@ variable "sns_parser_topic" {}
 
 variable "sns_batch_reconcile_topic" {}
 
+variable "disable_automated_reconciliation" {} 
+
 variable "region" {
   default = "ca-central-1"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,8 @@ variable "sns_reconciler_topic" {}
 
 variable "sns_parser_topic" {}
 
+variable "sns_batch_reconcile_topic" {}
+
 variable "region" {
   default = "ca-central-1"
 }


### PR DESCRIPTION
[CCFPCM-610](https://bcdevex.atlassian.net/browse/CCFPCM-610)

**Objective:** 

In order to run the reconciliation on the entire dataset as though it had run daily we should use the file metadata and filename (for SBC json files) to extract the date and run reconciliation based on that date. 

**How To Run On local:**

- Parsing, reconciliation and reports are now all automated by default. When you run sync/parse the entire dataset will be reconciled (job is >1 hr but should only need to run once per env unless you drop your db)

    - to test: ‘make drop', ‘make migrations-run’, ‘make sync’, 'make parse’ 

- Reconciliation can be run manually (only runs for the specified dates, does not batch):

    - 'make reconcile' and update reconcile.json

- Automated reconciliation can be turned off:

    - set DISABLE_AUTOMATED_RECONCILIATION=true

- Automated reports can be set to false in the reconciliation input:

   - "generateReport": false 

- Reports can be generated manually 

   - run 'make report' after updating report.json

- If you do not want to re-parse your data, or you only want to batch reconcile some of the data:

   - run 'make batch-reconcile' (uses default inputs for  Jan 1 to current date, these can be overridden in batch.json)

**How It Runs On Dev/Test:**

- Whenever data is dropped into the S3 bucket, either manually or via the sync job, it will be parsed and reconciled and will generate a report

- On dev, if you want to use the manual overrides you should drop your test data into the db and allow it to be parsed. Then, run the queries to reset the status to the pre-reconciled state. Now you can use the test tab in the lambdas to run manually. 
