### PR TITLE
[FIX] bastion metadata_options error

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -78,7 +78,9 @@ resource "aws_instance" "bastion_instance" {
   user_data                   = file("scripts/user-data.sh")
   
   metadata_options {
-    http_tokens = "required"
+    http_tokens                 = "required"
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
   }
 
   root_block_device {


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective: 

- Resolve the error below
- [terraform-provider-aws reference](https://github.com/hashicorp/terraform-provider-aws/issues/22465)
```
│ Error: creating EC2 Instance: InvalidParameterValue: A value of '' is not valid for HttpEndpoint. Specify either 'enabled' or 'disabled' and try again.
│       status code: 400, request id: 6bd7d5ab-f87b-4b94-ac19-a3dafee6cd86
│ 
│   with aws_instance.bastion_instance,
│   on bastion.tf line 69, in resource "aws_instance" "bastion_instance":
│   69: resource "aws_instance" "bastion_instance" {
│ 
╵
Operation failed: failed running terraform apply (exit 1)
make: *** [apply] Error 1
```