### PR TITLE
[CCFPCM-0000] Bundle dependencies as lambda layer 

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -44,6 +44,12 @@ jobs:
       - name: Build
         run: make build-backend
 
+      - name: Upload build artifacts
+        run: make aws-upload-artifacts
+      
+      - name: Publish new layer
+        run: make aws-publish-layer
+
       - name: Deploy Migrations
         run: make aws-deploy-migrator
 

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -45,6 +45,12 @@ jobs:
       - name: Build
         run: make build-backend
 
+      - name: Upload build artifacts
+        run: make aws-upload-artifacts
+      
+      - name: Publish new layer
+        run: make aws-publish-layer
+
       - name: Deploy migrations
         run: make aws-deploy-migrator
 

--- a/.github/workflows/deploy-zap-dev.yaml
+++ b/.github/workflows/deploy-zap-dev.yaml
@@ -46,6 +46,12 @@ jobs:
       - name: Build
         run: make build-backend
 
+      - name: Upload build artifacts
+        run: make aws-upload-artifacts
+      
+      - name: Publish new layer
+        run: make aws-publish-layer
+
       - name: Deploy migrations
         run: make aws-deploy-migrator
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+#####
+# Publishes the latest built layer to s3 and publishes a new lambda layer version
+# Usage: aws-publish-layer
+#####
+function aws-publish-layer() {
+	aws lambda publish-layer-version \
+		--layer-name "ppc-dependencies" \
+		--content S3Bucket=$APP_SRC_BUCKET,S3Key=$COMMIT_SHA/layer/nodejs.zip \
+		--compatible-runtimes nodejs18.x \
+		--region ca-central-1 \
+		--output text \
+		--query 'LayerVersionArn' \
+		--no-cli-pager
+}
+
+function aws-get-latest-layer-version() {
+    aws lambda list-layer-versions \
+            --layer-name ppc-dependencies \
+            --region ca-central-1 \
+            --query 'LayerVersions[0].LayerVersionArn'
+}
+
+#####
+# Updates the given lambda function to the latest code and layer version
+# Usage: aws-update-function-code <function-name>
+#####
+function aws-update-function-code() {
+	echo "Updating function code for $1...\n"
+	aws lambda update-function-code \
+        --function-name $1 \
+        --s3-bucket=$APP_SRC_BUCKET \
+        --s3-key=$COMMIT_SHA/backend/backend.zip \
+        --region ca-central-1 \
+        --no-cli-pager
+
+    latest_layer_version="$(aws-get-latest-layer-version)"
+
+	echo "Updating function layer for $1 to layer version $latest_layer_version \n"
+
+	aws lambda update-function-configuration \
+        --function-name $1 \
+        --layers [$latest_layer_version] \
+        --region ca-central-1 \
+        --no-cli-pager
+}
+
+#####
+# Updates the given lambda functions to the latest code and layer version
+# Usage: aws-deploy-function <function-name> <function-name> ... (as many as you want)
+#####
+function aws-deploy-function() {
+    # echo "$@"
+    echo "$#"
+    for funct in "${@:2}"; do
+        echo $funct;
+        aws-update-function-code $funct
+    done
+}
+
+# Check if the function exists and execute the given command
+if declare -f "$1" > /dev/null
+then
+  "$@" "${@:2}"
+else
+  echo "'$1' is not a known function name" >&2
+  exit 1
+fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,21 +5,21 @@
 # Usage: aws-publish-layer
 #####
 function aws-publish-layer() {
-	aws lambda publish-layer-version \
-		--layer-name "ppc-dependencies" \
-		--content S3Bucket=$APP_SRC_BUCKET,S3Key=$COMMIT_SHA/layer/nodejs.zip \
-		--compatible-runtimes nodejs18.x \
-		--region ca-central-1 \
-		--output text \
-		--query 'LayerVersionArn' \
-		--no-cli-pager
+  aws lambda publish-layer-version \
+    --layer-name "ppc-dependencies" \
+    --content S3Bucket=$APP_SRC_BUCKET,S3Key=$COMMIT_SHA/layer/nodejs.zip \
+    --compatible-runtimes nodejs18.x \
+    --region ca-central-1 \
+    --output text \
+    --query 'LayerVersionArn' \
+    --no-cli-pager
 }
 
 function aws-get-latest-layer-version() {
-    aws lambda list-layer-versions \
-            --layer-name ppc-dependencies \
-            --region ca-central-1 \
-            --query 'LayerVersions[0].LayerVersionArn'
+  aws lambda list-layer-versions \
+    --layer-name ppc-dependencies \
+    --region ca-central-1 \
+    --query 'LayerVersions[0].LayerVersionArn'
 }
 
 #####
@@ -27,23 +27,23 @@ function aws-get-latest-layer-version() {
 # Usage: aws-update-function-code <function-name>
 #####
 function aws-update-function-code() {
-	echo "Updating function code for $1...\n"
-	aws lambda update-function-code \
-        --function-name $1 \
-        --s3-bucket=$APP_SRC_BUCKET \
-        --s3-key=$COMMIT_SHA/backend/backend.zip \
-        --region ca-central-1 \
-        --no-cli-pager
+  echo "Updating function code for $1...\n"
+  aws lambda update-function-code \
+    --function-name $1 \
+    --s3-bucket=$APP_SRC_BUCKET \
+    --s3-key=$COMMIT_SHA/backend/backend.zip \
+    --region ca-central-1 \
+    --no-cli-pager > /dev/null
 
-    latest_layer_version="$(aws-get-latest-layer-version)"
+  latest_layer_version="$(aws-get-latest-layer-version)"
 
-	echo "Updating function layer for $1 to layer version $latest_layer_version \n"
+  echo "Updating function layer for $1 to layer version $latest_layer_version"
 
-	aws lambda update-function-configuration \
-        --function-name $1 \
-        --layers [$latest_layer_version] \
-        --region ca-central-1 \
-        --no-cli-pager
+  aws lambda update-function-configuration \
+    --function-name $1 \
+    --layers [$latest_layer_version] \
+    --region ca-central-1 \
+    --no-cli-pager > /dev/null
 }
 
 #####
@@ -51,17 +51,14 @@ function aws-update-function-code() {
 # Usage: aws-deploy-function <function-name> <function-name> ... (as many as you want)
 #####
 function aws-deploy-function() {
-    # echo "$@"
-    echo "$#"
-    for funct in "${@:2}"; do
-        echo $funct;
-        aws-update-function-code $funct
-    done
+  for funct in "${@:2}"; do
+    echo $funct
+    aws-update-function-code $funct
+  done
 }
 
 # Check if the function exists and execute the given command
-if declare -f "$1" > /dev/null
-then
+if declare -f "$1" >/dev/null; then
   "$@" "${@:2}"
 else
   echo "'$1' is not a known function name" >&2

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -92,3 +92,24 @@ resource "aws_s3_bucket_acl" "pcc_master_data_acl" {
   bucket = aws_s3_bucket.pcc-master-data.id
   acl    = "private"
 }
+
+
+resource "aws_s3_bucket" "pcc-deployments" {
+  bucket = "pcc-deployments-${var.target_env}"
+  tags = {
+    Name        = "pcc-deployments-${var.target_env}"
+    Environment = var.target_env
+  }
+}
+
+resource "aws_s3_bucket_versioning" "pcc-deployments" {
+  bucket = aws_s3_bucket.pcc-deployments.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "pcc-deployments" {
+  bucket = aws_s3_bucket.pcc-deployments.id
+  acl    = "private"
+}


### PR DESCRIPTION
[CCFPCM-0000](https://bcdevex.atlassian.net/browse/CCFPCM-0000)

Objective: 
**Reduce lambda bundle size**
Direct uploads of lambda deployment packages  are limited to 50mb. This PR adds support for bundling and node dependencies as a separate lambda layer that can be shared between the lambdas, and fixes this issue.

**Changes**
- Added s3 bucket for build artifacts. Lambda layers face the same 50mb limit for direct uploads, but a 250mb limit for layers deployed via an s3 bucket
- Updated build scripts to build two separate artifacts (<GIT_COMMIT_SHA>/backend/backend.zip and <GIT_COMMIT_SHA>/layer/nodejs.zip) that are uploaded to s3 
- Updated Github Actions workflows to upload artifacts and publishing a new lambda layer before deploying code changes
- Moved common deployment scripts into `deploy.sh` to keep things neat.
