### PR TITLE
[CCFPCM-570] cron job for daily file check alerting

### DIFF
--- a/apps/backend/src/database/migrations/1692293473030-migration.ts
+++ b/apps/backend/src/database/migrations/1692293473030-migration.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migration1692293473030 implements MigrationInterface {
+  name = 'migration1692293473030';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" DROP COLUMN "retries"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "program_daily_upload" DROP COLUMN "retries"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "program_daily_upload" ADD "retries" integer NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "file_ingestion_rules" ADD "retries" integer NOT NULL DEFAULT '0'`
+    );
+  }
+}

--- a/apps/backend/src/notification/entities/file-ingestion-rules.entity.ts
+++ b/apps/backend/src/notification/entities/file-ingestion-rules.entity.ts
@@ -11,8 +11,4 @@ export class FileIngestionRulesEntity {
 
   @OneToMany(() => ProgramRequiredFileEntity, (file) => file.rule)
   requiredFiles: ProgramRequiredFileEntity[];
-
-  // Number of retries before we send an alert
-  @Column({ type: 'int4', default: 0 })
-  retries: number;
 }

--- a/apps/backend/src/notification/entities/program-daily-upload.entity.ts
+++ b/apps/backend/src/notification/entities/program-daily-upload.entity.ts
@@ -25,10 +25,6 @@ export class ProgramDailyUploadEntity {
   @Column()
   success: boolean;
 
-  // Number of times we have tried uploading this grouping for a day
-  @Column({ type: 'int4' })
-  retries: number;
-
   @ManyToOne(() => FileIngestionRulesEntity)
   @JoinColumn()
   rule: Relation<FileIngestionRulesEntity>;

--- a/apps/backend/src/notification/notification.service.ts
+++ b/apps/backend/src/notification/notification.service.ts
@@ -87,7 +87,6 @@ export class NotificationService {
       const newDaily: Partial<ProgramDailyUploadEntity> = {
         dailyDate: date,
         success: false,
-        retries: 0,
         rule,
       };
       const daily = this.programDailyRepo.create(newDaily);

--- a/apps/backend/src/parse/parse.controller.ts
+++ b/apps/backend/src/parse/parse.controller.ts
@@ -12,7 +12,6 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiConsumes, ApiBasicAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { ParseService } from './parse.service';
-import { DailyAlertRO } from './ro/daily-alert.ro';
 import { FileTypes } from '../constants';
 import { CashDepositService } from '../deposits/cash-deposit.service';
 import { PosDepositService } from '../deposits/pos-deposit.service';
@@ -113,28 +112,5 @@ export class ParseController {
 
     //TODO call parse service to process file event
     throw new HttpException('Not Implemented', 501);
-  }
-  /**
-   * Makes decisions on whether to send an alert (or error log) for our programs for a date
-   * Based on the daily program status, and which files are required by the rules
-   * @returns Array of DailyAlertROs to determine which programs are successful and which programs have been alerted
-   */
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        date: {
-          type: 'string',
-          nullable: false,
-          example: '2023-01-01',
-        },
-      },
-    },
-  })
-  @Post('daily-upload/alert')
-  async dailyUploadAlert(
-    @Body() body: { date: string }
-  ): Promise<DailyAlertRO> {
-    return await this.alertService.dailyUploadAlert(body.date);
   }
 }

--- a/apps/backend/src/parse/parse.service.ts
+++ b/apps/backend/src/parse/parse.service.ts
@@ -487,7 +487,7 @@ export class ParseService {
       if (!daily) {
         throw new Error('Error');
       }
-      const missingFiles = await this.notificationService.findMissingDailyFiles(
+      const missingFiles = this.notificationService.findMissingDailyFiles(
         rules,
         daily.files
       );

--- a/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
+++ b/apps/backend/test/mocks/classes/file_ingestion_rules_mock.ts
@@ -9,7 +9,6 @@ export class FileIngestionRulesMock extends FileIngestionRulesEntity {
     super();
     this.id = faker.datatype.uuid();
     this.program = program;
-    this.retries = faker.datatype.number({ min: 0, max: 3 });
     this.requiredFiles = [];
   }
 

--- a/terraform/lambda_dailyfilecheck.tf
+++ b/terraform/lambda_dailyfilecheck.tf
@@ -39,3 +39,22 @@ resource "aws_lambda_function" "daily-alert" {
     ]
   }
 }
+
+resource "aws_lambda_permission" "daily_alert_cloudwatch_permission" {
+  function_name = aws_lambda_function.daily-alert.function_name
+  statement_id = "CloudWatchInvoke"
+  action = "lambda:InvokeFunction"
+
+  source_arn = aws_cloudwatch_event_rule.daily_alert_trigger.arn
+  principal = "events.amazonaws.com"
+}
+
+resource "aws_cloudwatch_event_rule" "daily_alert_trigger" {
+  name = "daily"
+  schedule_expression = "cron(0 11,14,17 * * *)"
+}
+
+resource "aws_cloudwatch_event_target" "invoke_daily_alert" {
+  rule = aws_cloudwatch_event_rule.daily_alert_trigger.name
+  arn = aws_lambda_function.daily-alert.arn
+}


### PR DESCRIPTION
[CCFPCM-570](https://bcdevex.atlassian.net/browse/CCFPCM-570)
[CCFPCM-612](https://bcdevex.atlassian.net/browse/CCFPCM-612)

Objective: 
- Automate alerts with a cron job using cloudwatch events at 11, 14, 17 (this may need to be adjusted depending on timezone)
- Only alert if files have been sent in across any LOB for the day
- We stop sending alerts if a daily upload was incomplete 7+ days ago. We can remove this logic; I just figure at that point, if files have continued to be uploaded, we can reconcile?
- Remove concept of "retries" as it's now in set times

