### PR TITLE
[CCFPCM-570] change to utc, proper cron expression (specialied AWS cron)

### DIFF
--- a/terraform/lambda_dailyfilecheck.tf
+++ b/terraform/lambda_dailyfilecheck.tf
@@ -51,7 +51,7 @@ resource "aws_lambda_permission" "daily_alert_cloudwatch_permission" {
 
 resource "aws_cloudwatch_event_rule" "daily_alert_trigger" {
   name = "daily"
-  schedule_expression = "cron(0 11,14,17 * * *)"
+  schedule_expression = "cron(0 0,18,21 * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "invoke_daily_alert" {


### PR DESCRIPTION
[CCFPCM-570](https://bcdevex.atlassian.net/browse/CCFPCM-570)

Objective: 
I noted that the times in the scheduled expression are utc, so I adjusted accordingly. I also found that AWS cron needs 6 stars (the question mark here being for 'day of week').



