### PR TITLE
[CCFPCM-606] Added budget + alerts when exceeding target

### DIFF
--- a/terraform/budget.tf
+++ b/terraform/budget.tf
@@ -1,0 +1,25 @@
+locals {
+    total_monthly_budget_amount = "600"
+    total_monthly_budget_threshold_percentage = "100"
+    total_monthly_budget_subscribers = ["Pay.Digital@gov.bc.ca"]
+}
+
+
+
+resource "aws_budgets_budget" "budget-monthly" {
+    name = "Total Monthly Budget (${local.environment})"
+    budget_type = "COST"
+    limit_amount = local.total_monthly_budget_amount
+    limit_unit = "USD"
+    time_period_end = "2087-06-15_00:00"
+    time_period_start = "2023-08-01_00:00"
+    time_unit = "MONTHLY"
+
+    notification {
+        comparison_operator = "GREATER_THAN"
+        threshold = local.total_monthly_budget_threshold_percentage
+        threshold_type = "PERCENTAGE"
+        notification_type = "ACTUAL"
+        subscriber_email_addresses = local.total_monthly_budget_subscribers
+    }
+}


### PR DESCRIPTION
[CCFPCM-606](https://bcdevex.atlassian.net/browse/CCFPCM-606)

Objective: 

Added alert sent to provided email address when exceeding monthly target budget per environment.

Sample of what this notification will look like (note: amounts in this preview are not accurate, as they were just set to make sure the emails would trigger)
![image](https://github.com/bcgov/PaymentCommonComponent/assets/66635118/5b3c3da4-a2ef-4ebc-b12f-1a47069a73f7)

