### PR TITLE
[CCFPCM-597] Enabled RDS logging + export to Cloudwatch

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -27,6 +27,7 @@ resource "aws_rds_cluster" "pgsql" {
 
   db_subnet_group_name   = aws_db_subnet_group.pgsql.name
   vpc_security_group_ids = [data.aws_security_group.data.id]
+  enabled_cloudwatch_logs_exports = ["postgresql"]
 
   # 2AM-4AM PST
   preferred_backup_window = "09:00-11:00"


### PR DESCRIPTION
[CCFPCM-597](https://bcdevex.atlassian.net/browse/CCFPCM-597)

Objective: 

Enabled export of postgres logs to CloudWatch in order to resolve the "Enable additional RDS logging" Security Hub alert. This will create a CloudWatch log group called `/aws/rds/cluster/{db cluster name}/postgresql` where the logs can be found.

This may or may not be sufficient to resolve CCFPCM-407 - AC 2: Ability send reports of access to Auditors, depending on the verbosity of these logs. Will verify once deployed

