### PR TITLE
[CCFPCM-407] Enabled RDS pgAudit extension

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -2,9 +2,9 @@ locals {
   pgaudit_role_name = "rds_pgaudit"
   rds_engine = "aurora-postgresql"
   rds_engine_version = "13.8"
+  rds_engine_version_short = "13"
   parameter_group_params = {
     shared_preload_libraries = "pgaudit"
-    client_encoding    = "utf8"
     log_connections    = "1"
     log_disconnections = "1"
 
@@ -56,22 +56,16 @@ resource "aws_rds_cluster" "pgsql" {
     ]
   }
 }
-resource "postgresql_extension" "pgsql-pgaudit-extension" {
-  name = "pgaudit"
-}
 
-resource "postgresql_role" "rds_pgaudit_role" {
-  name = local.pgaudit_role_name
-}
 resource "aws_db_parameter_group" "pgsql-audit-param-group" {
   count = 1
   name = "pgsql-audit-param-group"
-  family = "${local.rds_engine}${local.rds_engine_version}"
+  family = "${local.rds_engine}${local.rds_engine_version_short}"
   // Load pgaudit extension 
   dynamic "parameter" {
     for_each = local.parameter_group_params
     content {
-      apply_method = "pending_reboot"
+      apply_method = "pending-reboot"
       name = parameter.key
       value = parameter.value
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,12 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.55.0"
     }
+    postgresql = {
+      source = "cyrilgdn/postgresql"
+      version = "1.20.0"
+    }
   }
+  
 
   backend "remote" {}
 }
@@ -15,3 +20,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${var.target_aws_account_id}:role/BCGOV_${var.target_env}_Automation_Admin_Role"
   }
 }
+
+provider "postgresql" {
+  host      = aws_rds_cluster.pgsql.endpoint
+  database  = aws_rds_cluster.pgsql.database_name
+  username  = aws_rds_cluster.pgsql.master_username
+  password  = data.aws_ssm_parameter.postgres_password.value
+  sslmode   = "require"
+  connect_timeout = 15
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.55.0"
     }
-    postgresql = {
-      source = "cyrilgdn/postgresql"
-      version = "1.20.0"
-    }
   }
   
 
@@ -20,13 +16,3 @@ provider "aws" {
     role_arn = "arn:aws:iam::${var.target_aws_account_id}:role/BCGOV_${var.target_env}_Automation_Admin_Role"
   }
 }
-
-provider "postgresql" {
-  host      = aws_rds_cluster.pgsql.endpoint
-  database  = aws_rds_cluster.pgsql.database_name
-  username  = aws_rds_cluster.pgsql.master_username
-  password  = data.aws_ssm_parameter.postgres_password.value
-  sslmode   = "require"
-  connect_timeout = 15
-}
-


### PR DESCRIPTION
[CCFPCM-407](https://bcdevex.atlassian.net/browse/CCFPCM-407)

Objective: 
- Enabled the `pgaudit` postgres extension to capture DB audit logs to meet audit and reporting requirements.
- Audit logs is output to the `aws/rds/cluster/pcc-db/postgresql` CloudWatch group
- pgAudit has been configured to log "ALL" statements, this can be tweaked in the new RDS parameter group created in this PR. Available options can be found here: https://access.crunchydata.com/documentation/pgaudit/latest/#settings

Changes:
- Enables `pgaudit` extension
- Creates new `rds_pgaudit` db role for use by pgaudit
- Creates new RDS Param group `pgsql-audit-param-group` to configure pgaudit

