### PR TITLE
[CCFPCM-407] Enabled s3 access logging

### DIFF
--- a/terraform/sftp.tf
+++ b/terraform/sftp.tf
@@ -64,6 +64,11 @@ POLICY
 
 resource "aws_s3_bucket" "sftp_storage" {
   bucket = "pcc-integration-data-files-${var.target_env}"
+
+  logging {
+    target_bucket = aws_s3_bucket.pcc-s3-access-logs.id
+    target_prefix = "logs/pcc-integration-data-files-${var.target_env}/"
+  }
 }
 
 resource "aws_s3_bucket_policy" "allow_prod_to_access_other_envs" {


### PR DESCRIPTION
[CCFPCM-407](https://bcdevex.atlassian.net/browse/CCFPCM-407)

Objective: 
- Enabled s3 access logging (https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html)

Changes:
- Created new s3 bucket for storing S3 access logs (`pcc-s3-access-logs-${var.target_env}`)
- Enabled access logging on existing s3 buckets

