### PR TITLE
[CCFPCM-407] Disabled rds backups in dev, increased retention period in test to match prod

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -31,7 +31,7 @@ resource "aws_rds_cluster" "pgsql" {
 
   # 2AM-4AM PST
   preferred_backup_window = "09:00-11:00"
-  backup_retention_period = var.target_env == "prod" ? 14 : 3
+  backup_retention_period = var.target_env == "dev" ? 0: 14
 
   lifecycle {
     # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#argument-reference


### PR DESCRIPTION
[CCFPCM-407](https://bcdevex.atlassian.net/browse/CCFPCM-407)

Objective: 
- Disabled DB backups in dev environment
- Increased DB backup retention period in test environment to match production (14 days). This will also resolve the DB backup not enabled alert in security hub which required a minimum 7 day retention period. 

