### PR TITLE
[CCFPCM-630] alert for all unsuccessful statuses in past 7 days

### DIFF
--- a/apps/backend/src/lambdas/dailyfilecheck.ts
+++ b/apps/backend/src/lambdas/dailyfilecheck.ts
@@ -4,14 +4,48 @@ import { format, isSameDay, subDays } from 'date-fns';
 import { ProgramTemplateName } from './const';
 import { AppModule } from '../app.module';
 import { AppLogger } from '../logger/logger.service';
-import { AlertDestinationEntity } from '../notification/entities/alert-destination.entity';
 import { MAIL_TEMPLATE_ENUM } from '../notification/mail-templates';
 import { MailService } from '../notification/mail.service';
 import { NotificationService } from '../notification/notification.service';
+import { ProgramRequiredFileEntity } from '../parse/entities/program-required-file.entity';
 
 const ALERT_EXPIRY_DAYS = 7; // Num days before we stop alerting for a LOB if they haven't submitted all files for a day
 
 export const handler = async (event: unknown, context?: Context) => {
+  const sendMissingFilesEmail = async (
+    program: string,
+    destinations: string[],
+    errorsMessage: string
+  ) => {
+    appLogger.log('Daily file check showing errors:');
+    appLogger.log(errorsMessage);
+
+    appLogger.log('\n\n=========Alerts Sent for Daily Upload: =========\n');
+    appLogger.error(`Sending an alert to prompt ${program} to complete upload`);
+
+    await mailService.sendEmailAlertBulk(
+      MAIL_TEMPLATE_ENUM.FILES_MISSING_ALERT,
+      destinations,
+      [
+        {
+          fieldName: 'date',
+          content: format(new Date(), 'MMM do, yyyy'),
+        },
+        {
+          fieldName: 'ministryDivision',
+          content: `${
+            process.env.NODE_ENV !== 'production' &&
+            `[${process.env.NODE_ENV}] `
+          }${program}`,
+        },
+        {
+          fieldName: 'error',
+          content: errorsMessage,
+        },
+      ]
+    );
+  };
+
   const app = await NestFactory.createApplicationContext(AppModule);
   const appLogger = app.get(AppLogger);
   appLogger.setContext('Daily File Check Lambda');
@@ -34,6 +68,7 @@ export const handler = async (event: unknown, context?: Context) => {
     allRecentStatuses.filter((status) => isSameDay(status.created_at, date))
       .length === 0
   ) {
+    appLogger.log('No uploads today, we will not send out any alerts');
     // No files have been sent in today, skip alerting for off days
     // Assumption: At least one file upload should have arrived on time from any LOB
     return;
@@ -51,60 +86,62 @@ export const handler = async (event: unknown, context?: Context) => {
       `${unsuccessfulStatuses.length} unsuccessful days in the past ${ALERT_EXPIRY_DAYS} days`
     );
 
-    // Alert - This program has files missing either today or in past days
+    const allMissingFiles: ProgramRequiredFileEntity[] = [];
+    unsuccessfulStatuses.forEach((st) => {
+      const mfiles = notificationService.findMissingDailyFiles(rule, st.files);
+      allMissingFiles.push(...mfiles);
+    });
+
     if (unsuccessfulStatuses.length > 0) {
-      const earliestStatus = unsuccessfulStatuses[0]; // Query should be ordered by daily date
-      const errors: string[] = [];
       const program =
         ProgramTemplateName[rule.program as keyof typeof ProgramTemplateName];
 
-      const incompleteString = `Daily Upload for ${program} is incomplete for date: ${earliestStatus.dailyDate}.\n`;
-      errors.push(incompleteString);
-
-      const missingFiles = notificationService.findMissingDailyFiles(
-        rule,
-        earliestStatus.files
+      const allAlertDestinations = await mailService.getAlertDestinations(
+        program,
+        allMissingFiles.map((mf) => mf.filename)
       );
-      missingFiles.forEach((file) => {
-        errors.push(`Missing a ${file.fileType} - needs ${file.filename}\n`);
-      });
 
-      appLogger.log(errors.join(' '));
-      const alertDestinationEntities: AlertDestinationEntity[] =
-        await mailService.getAlertDestinations(
-          program,
-          missingFiles.map((mf) => mf.filename)
+      // Send a summary to destinations with 'ALL' and 'RULE' of all missing files
+      const ruleDestinations = allAlertDestinations.filter(
+        (ad) => ad.allAlerts || ad.rule?.id === rule.id
+      );
+      const ruleErrors: string[] = [];
+      for (const status of unsuccessfulStatuses) {
+        const incompleteString = `Daily Upload for ${program} is incomplete for date: ${status.dailyDate}.\n`;
+        ruleErrors.push(incompleteString);
+        const missingFiles = notificationService.findMissingDailyFiles(
+          rule,
+          status.files
         );
 
-      const alertDestinations = alertDestinationEntities.map(
-        (itm) => itm.destination
-      );
+        // For each missing file, send an email to destinations that point to the specific filetype
+        const fileErrors: string[] = [];
+        missingFiles.map(async (file) => {
+          const fileAlertDestinations = allAlertDestinations.filter(
+            (ad) => ad.requiredFile?.id === file.id
+          );
+          if (fileAlertDestinations.length > 0) {
+            fileErrors.push(incompleteString);
+            fileErrors.push(
+              `Missing a ${file.fileType} - needs ${file.filename}\n`
+            );
+            await sendMissingFilesEmail(
+              program,
+              fileAlertDestinations.map((ad) => ad.destination),
+              fileErrors.join(' ')
+            );
+          }
 
-      if (!alertDestinations.length || !program) {
-        continue;
+          // Add this missing file string to the more general rule / all error message
+          ruleErrors.push(
+            `Missing a ${file.fileType} - needs ${file.filename}\n`
+          );
+        });
       }
-
-      appLogger.log('\n\n=========Alerts Sent for Daily Upload: =========\n');
-      appLogger.error(
-        `Sending an alert to prompt ${program} to complete upload`
-      );
-      await mailService.sendEmailAlertBulk(
-        MAIL_TEMPLATE_ENUM.FILES_MISSING_ALERT,
-        alertDestinations.map((ad) => ad),
-        [
-          {
-            fieldName: 'date',
-            content: format(new Date(), 'MMM do, yyyy'),
-          },
-          {
-            fieldName: 'ministryDivision',
-            content: program,
-          },
-          {
-            fieldName: 'error',
-            content: errors.join(' '),
-          },
-        ]
+      await sendMissingFilesEmail(
+        program,
+        ruleDestinations.map((ad) => ad.destination),
+        ruleErrors.join(' ')
       );
     }
   }

--- a/apps/backend/src/lambdas/dailyfilecheck.ts
+++ b/apps/backend/src/lambdas/dailyfilecheck.ts
@@ -34,8 +34,8 @@ export const handler = async (event: unknown, context?: Context) => {
         {
           fieldName: 'ministryDivision',
           content: `${
-            process.env.NODE_ENV !== 'production' &&
-            `[${process.env.NODE_ENV}] `
+            process.env.RUNTIME_ENV !== 'production' &&
+            `[${process.env.RUNTIME_ENV}] `
           }${program}`,
         },
         {

--- a/apps/backend/src/lambdas/dailyfilecheck.ts
+++ b/apps/backend/src/lambdas/dailyfilecheck.ts
@@ -95,6 +95,9 @@ export const handler = async (event: unknown, context?: Context) => {
     if (unsuccessfulStatuses.length > 0) {
       const program =
         ProgramTemplateName[rule.program as keyof typeof ProgramTemplateName];
+      if (!program) {
+        continue;
+      }
 
       const allAlertDestinations = await mailService.getAlertDestinations(
         program,

--- a/apps/backend/src/lambdas/parser.ts
+++ b/apps/backend/src/lambdas/parser.ts
@@ -17,7 +17,8 @@ export const handler = async (event: S3Event, _context?: Context) => {
   const parseService = app.get(ParseService);
   const snsService = app.get(SnsManagerService);
 
-  const automationDisabled = process.env.DISABLE_AUTOMATED_RECONCILIATION;
+  const automationDisabled =
+    process.env.DISABLE_AUTOMATED_RECONCILIATION === 'true';
 
   const isLocal: boolean = process.env.RUNTIME_ENV === 'local';
 

--- a/apps/backend/src/notification/entities/alert-destination.entity.ts
+++ b/apps/backend/src/notification/entities/alert-destination.entity.ts
@@ -33,7 +33,7 @@ export class AlertDestinationEntity {
   // Send all alerts for a specific file type / data source to this destination
   @ManyToOne(() => ProgramRequiredFileEntity, { nullable: true })
   @JoinColumn({ name: 'required_file_id' })
-  requiredFile: ProgramRequiredFileEntity;
+  requiredFile?: ProgramRequiredFileEntity;
 
   // Typically email; can eventually be a phone number if necessary
   @Column({ nullable: false })

--- a/apps/backend/src/notification/mail.service.ts
+++ b/apps/backend/src/notification/mail.service.ts
@@ -37,7 +37,7 @@ export class MailService {
    */
   public async getAlertDestinations(
     program: string,
-    filenames: string[]
+    filenames?: string[]
   ): Promise<AlertDestinationEntity[]> {
     const allDestinations = await this.destinationRepo.find({
       relations: {
@@ -51,6 +51,7 @@ export class MailService {
           destination.allAlerts === true ||
           destination.rule?.program === program ||
           (destination.requiredFile &&
+            filenames &&
             filenames.includes(destination.requiredFile.filename))
       )
       .filter((destination) => destination)


### PR DESCRIPTION
[CCFPCM-570](https://bcdevex.atlassian.net/browse/CCFPCM-570)
[CCFPCM-630](https://bcdevex.atlassian.net/browse/CCFPCM-630)
[CCFPCM-631(https://bcdevex.atlassian.net/browse/CCFPCM-631)

Objective: 
Using the earliest status could miss a lot of the issues in between, so we are now alerting for all the daily issues. Change in logic to email all / rule destinations a summary, and file destinations a single email per file
