### PR TITLE
[CHORE] point prod deployment to new github env

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     concurrency: ci-${{ github.ref }}-prod
     environment:
-      name: prod
+      name: prod-deployment
     steps:
       - uses: actions/checkout@v3
         name: checkout
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload build artifacts
         run: make aws-upload-artifacts
-      
+
       - name: Deploy Migrations
         run: make aws-deploy-migrator
 
@@ -55,4 +55,3 @@ jobs:
 
       - name: Deploy All
         run: aws-deploy-all
-


### PR DESCRIPTION
Objective: 
Point the prod deployment workflow to the new ENV which requires approvals.
NOTE: The new ENV has been tested by a branch that points the S3 sync to it. I was prompted to approve, and we can see from this screenshot that the AWS creds are correct, and that the error it throws is the same as the usual errors (single file issue)
![Screenshot 2023-08-31 at 6 41 17 PM](https://github.com/bcgov/PaymentCommonComponent/assets/61991654/b74394dd-f031-4754-8cbe-b8b7810b143a)
