### PR TITLE
[CCFPCM-602] Fixed db migrations not running in dev

### DIFF
--- a/apps/backend/src/database/datasource.ts
+++ b/apps/backend/src/database/datasource.ts
@@ -2,6 +2,40 @@ import { DataSource } from 'typeorm';
 import { entities } from './entity.config';
 import { dbLogger, logLevels } from './helpers';
 
+const migrationsFolder = [__dirname + '/migrations/**/*{.ts,.js}'];
+
+// Load migrations using Webpack contexts when building the app using webpack.
+// This is necessary seeing as webpack bundles all app files, so there won't
+// be any migrations in the /migrations folder for typeorm to pick up.
+const loadMigrationsWithWebpack = () => {
+  const context = (<any>require).context('./migrations', true, /\.js|\.ts/); // eslint-disable-line @typescript-eslint/no-explicit-any
+  return context
+    .keys()
+    .sort()
+    .map((fn: string) => {
+      const module = context(fn);
+
+      return Object.keys(module).reduce((result, key) => {
+        const exportedEntity = module[key];
+
+        if (typeof exportedEntity === 'function') {
+          return result.concat(exportedEntity);
+        }
+
+        return result;
+      }, []);
+    })
+    .flat();
+};
+
+let migrations;
+
+try {
+  migrations = loadMigrationsWithWebpack();
+} catch (e) {
+  migrations = migrationsFolder;
+}
+
 export default new DataSource({
   type: 'postgres',
   host: process.env.DB_HOST ?? 'localhost',
@@ -10,7 +44,7 @@ export default new DataSource({
   password: process.env.DB_PASSWORD ?? 'postgres',
   database: process.env.DB_NAME ?? 'pcc',
   entities,
-  migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
+  migrations: migrations,
   synchronize: false,
   logging: logLevels,
   logger: dbLogger,


### PR DESCRIPTION
[CCFPCM-602](https://bcdevex.atlassian.net/browse/CCFPCM-602)

Objective: 
Fixes DB migrations when running the migrator lambda. New migrations are currently not being picked up by typeorm when running the Migrator lambda. Typeorm can't find any migrations to run in the `/migrations` folder seeing as Webpack bundles them together with the app.

Solution:
Dynamically load migrations using webpack contexts, which will let us keep a reference to the migrations after the app has been built. When running it locally, it will still use the glob pattern to look up the migrations, as it's not using webpack at that time.