### PR TITLE
[CCFPCM-595] Re-enable backups of dev db

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -47,7 +47,7 @@ resource "aws_rds_cluster" "pgsql" {
 
   # 2AM-4AM PST
   preferred_backup_window = "09:00-11:00"
-  backup_retention_period = var.target_env == "dev" ? 0: 14
+  backup_retention_period = var.target_env == "dev" ? 1: 14
 
   lifecycle {
     # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#argument-reference


### PR DESCRIPTION
[CCFPCM-595](https://bcdevex.atlassian.net/browse/CCFPCM-595)

Objective: 

Turns out you cannot actually disable backups on Aurora DBs, so set the backup retention period to a minimum of 1 day for the dev environment.

![image](https://github.com/bcgov/PaymentCommonComponent/assets/66635118/69cb3aec-7872-47b3-b5e3-e0aad883e7d8)
![image](https://github.com/bcgov/PaymentCommonComponent/assets/66635118/8e50a1a8-da04-4b5f-8326-947d33173121)



