### PR TITLE
[FIX] local migrations/seed data

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -40,7 +40,7 @@ jobs:
         run: make build
 
       - name: Run migrations
-        run: make migration-run
+        run: make migration-run-ci
 
       - name: Build and Run Test Container
         run: make run-test

--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,9 @@ migration-revert:
 	@docker-compose exec -T backend yarn workspace @payment/backend typeorm:revert-migration
 
 migration-run:
+	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/database/migrate.ts")'
+	
+migration-run-ci:
 	@docker-compose exec -T backend yarn workspace @payment/backend typeorm:run-migrations
 
 migration-generate:	  


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective: 

- we need to call the migrate lambda in order for the seed data to run
- I have updated the Makefile cmd to trigger the migrations from the lambda instead of the typeorm cli 