### PR TITLE
[CCFPCM-590] Added missing s3 access log permission to bucket

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -138,6 +138,20 @@ resource "aws_s3_bucket" "pcc-s3-access-logs" {
   }
 }
 
+
+resource "aws_s3_bucket_ownership_controls" "pcc-s3-access-logs-ownership" {
+  bucket = aws_s3_bucket.pcc-s3-access-logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "pcc-s3-access-logs-acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.pcc-s3-access-logs-ownership]
+  bucket = aws_s3_bucket.pcc-s3-access-logs.id
+  acl    = "log-delivery-write"
+}
+
 resource "aws_s3_bucket_versioning" "pcc-s3-access-logs" {
   bucket = aws_s3_bucket.pcc-s3-access-logs.id
   versioning_configuration {

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -155,7 +155,7 @@ resource "aws_s3_bucket_acl" "pcc-s3-access-logs-acl" {
 resource "aws_s3_bucket_versioning" "pcc-s3-access-logs" {
   bucket = aws_s3_bucket.pcc-s3-access-logs.id
   versioning_configuration {
-    status = "Disabled"
+    status = "Enabled"
   }
 }
 


### PR DESCRIPTION
[CCFPCM-590](https://bcdevex.atlassian.net/browse/CCFPCM-590)

Objective: 

Added missing ACL to S3 access log bucket. It needs the `log-delivery-write` acl in order to receive access logs from the other buckets

