### PR TITLE
[FIX] remove handler() call from migrator lambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ migration-revert:
 	@docker-compose exec -T backend yarn workspace @payment/backend typeorm:revert-migration
 
 migration-run:
-	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/database/migrate.ts")'
+	@docker exec -it $(PROJECT)-backend ./node_modules/.bin/ts-node -e 'require("./apps/backend/src/database/migrate.ts").handler()'
 	
 migration-run-ci:
 	@docker-compose exec -T backend yarn workspace @payment/backend typeorm:run-migrations

--- a/apps/backend/src/database/migrate.ts
+++ b/apps/backend/src/database/migrate.ts
@@ -42,5 +42,3 @@ export const handler = async (_event?: unknown, _context?: Context) => {
     return 'failure';
   }
 };
-
-handler();


### PR DESCRIPTION
Should address [CCFPCM-630](https://bcdevex.atlassian.net/browse/CCFPCM-630)

Objective: 
Noticed that the migrator logic created both locations and rules twice. This should take care of that