### PR TITLE
[CCFPCM-589] Force SSL traffic to S3 buckets + block public ACLs

### DIFF
--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -14,12 +14,3 @@ resource "aws_s3_bucket_acl" "local_development_acl" {
   bucket = aws_s3_bucket.local_development[0].id
   acl    = "private"
 }
-
-resource "aws_s3_bucket_public_access_block" "local_development" {
-  count = var.target_env == "dev" ? 1 : 0
-  bucket                  = aws_s3_bucket.local_development[0].id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -2,10 +2,24 @@
 resource "aws_s3_bucket" "local_development" {
   count = var.target_env == "dev" ? 1 : 0
   bucket = "pcc-integration-data-files-local"
+
+  logging {
+    target_bucket = aws_s3_bucket.pcc-s3-access-logs.id
+    target_prefix = "logs/pcc-integration-data-files-local/"
+  }
 }
 
 resource "aws_s3_bucket_acl" "local_development_acl" {
   count = var.target_env == "dev" ? 1 : 0
   bucket = aws_s3_bucket.local_development[0].id
   acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "local_development" {
+  count = var.target_env == "dev" ? 1 : 0
+  bucket                  = aws_s3_bucket.local_development[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }


### PR DESCRIPTION
[CCFPCM-589](https://bcdevex.atlassian.net/browse/CCFPCM-589)

Objective: 
- Enabled SSL enforcement on all S3 buckets
- Added policies to block public ACLs to all S3 buckets.




