### PR TITLE
[CCFPCM-0679] Bugfix for manual parsing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,8 @@ aws-build-and-deploy-aws-data-clear-lambda: build-backend aws-upload-artifacts a
 	
 
 aws-sync-files-from-prod-to-dev:
-	@aws s3 sync s3://pcc-integration-data-files-prod/sbc s3://pcc-integration-data-files-dev/sbc --acl bucket-owner-full-control
 	@aws s3 sync s3://pcc-integration-data-files-prod/bcm s3://pcc-integration-data-files-dev/bcm --acl bucket-owner-full-control
+	@aws s3 sync s3://pcc-integration-data-files-prod/sbc s3://pcc-integration-data-files-dev/sbc --acl bucket-owner-full-control
 
 aws-sync-files-from-prod-to-test:
 	@aws s3 sync s3://pcc-integration-data-files-prod/sbc s3://pcc-integration-data-files-test/sbc --acl bucket-owner-full-control
@@ -381,6 +381,8 @@ minio-ls:
 minio-rm:
 	@mc rm --recursive --force s3/pcc-integration-data-files-local
 
+minio-rm-archive:
+	@mc rm --recursive --force s3/pcc-integration-data-files-local/archive
 # ===================================
 # SFTP Data Sync
 # ===================================

--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -12,8 +12,10 @@ do
             
             echo -e "\nSyncing AWS PROD TO LOCAL..."
             source $REPO_LOCATION/bin/assume.sh "prod" "local"
-            rclone sync s3:pcc-integration-data-files-prod minio:pcc-integration-data-files-local 
-	        rclone check s3:pcc-integration-data-files-prod minio:pcc-integration-data-files-local
+            rclone sync s3:pcc-integration-data-files-prod/bcm minio:pcc-integration-data-files-local/bcm 
+	        rclone check s3:pcc-integration-data-files-prod/bcm minio:pcc-integration-data-files-local/bcm
+            rclone sync s3:pcc-integration-data-files-prod/sbc minio:pcc-integration-data-files-local/sbc 
+	        rclone check s3:pcc-integration-data-files-prod/sbc minio:pcc-integration-data-files-local/sbc
             
             break
             ;;


### PR DESCRIPTION
[CCFPCM-0679](https://bcdevex.atlassian.net/browse/CCFPCM-0679)

Objective: 
- The data bucket has too many items to list in a single call when manually parsing. This does not affected automated parsing as we are simply parsing the files dropped in through the automation flow, vs comparing the filelist from s3 with the db file upload table. 

- remove archive from dev/local and do not sync the archive folder