### PR TITLE
[CCFPCM-672] add errors to limit file extensions

### DIFF
--- a/apps/backend/src/constants.ts
+++ b/apps/backend/src/constants.ts
@@ -6,6 +6,11 @@ import { TDI34Header } from './flat-files/tdi34/TDI34Header';
 import { PosHeuristicRound } from './reconciliation/types';
 import { PaymentEntity, PaymentMethodEntity } from './transaction/entities';
 
+enum FileExtensions {
+  DAT = 'DAT',
+  JSON = 'JSON"',
+}
+
 export const ALL = 'all';
 
 export enum Ministries {
@@ -80,3 +85,11 @@ export interface NormalizedLocation {
 }
 
 export const BankMerchantId = 999999999;
+
+export const SUPPORTED_FILE_EXTENSIONS: {
+  [key: string]: string[];
+} = {
+  [FileTypes.TDI17]: [FileExtensions.DAT],
+  [FileTypes.TDI34]: [FileExtensions.DAT],
+  [FileTypes.SBC_SALES]: [FileExtensions.JSON],
+};


### PR DESCRIPTION
[CCFPCM-0000](https://bcdevex.atlassian.net/browse/CCFPCM-627)

Objective: 
Limit file extensions coming in on the API endpoint


