### PR TITLE
[FIX] Runtime env in terraform + block public acls on report bucket

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "api" {
     variables = {
       APP_VERSION                   = var.app_version
       NODE_ENV                      = "production"
-      RUNTIME_ENV                   = "hosted"
+      RUNTIME_ENV                   = var.target_env
       APP_VERSION                   = var.app_version
       DB_USER                       = var.db_username
       DB_PASSWORD                   = data.aws_ssm_parameter.postgres_password.value

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -26,6 +26,29 @@ resource "aws_s3_bucket" "pcc-reporting" {
     target_prefix = "logs/${local.pcc-reporting-bucket-name}/"
   }
 }
+resource "aws_s3_bucket_ownership_controls" "pcc_reporting_ownership" {
+  bucket = aws_s3_bucket.pcc-reporting.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pcc_reporting_pb" {
+  bucket = aws_s3_bucket.pcc-reporting.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+
+
+resource "aws_s3_bucket_acl" "pcc_reporting_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.pcc_reporting_ownership]
+  bucket     = aws_s3_bucket.pcc-reporting.id
+  acl        = "private"
+}
 
 resource "aws_s3_bucket_versioning" "pcc-reporting" {
   bucket = aws_s3_bucket.pcc-reporting.id


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective: 
- Fix runtime env variable for the lambda api (required for uploading files to the bucket)
- Fix the public acl block on reporting bucket (I noticed that it had changed during a terraform plan - I think this was leftover from updating the prod infra/migrating the terraform backend)
- Tried to increase the request limit on the api but still getting an error for large files

