### PR TITLE
[FIX] remove clear dev data func from test and prod envs

### DIFF
--- a/terraform/clear-dev-db.tf
+++ b/terraform/clear-dev-db.tf
@@ -1,3 +1,9 @@
+locals {
+  // Disable this on prod and test
+  clear_data_disabled_envs      = ["prod", "test"]
+  clear_dev_data_resource_count = contains(local.transfer_family_disabled_envs, var.target_env) == true ? 0 : 1
+}
+
 resource "aws_lambda_function" "clearDevData" {
   description                    = "Database clear ${var.target_env} Data function ${local.namespace}"
   function_name                  = "clear_${var.target_env}_data"
@@ -20,7 +26,7 @@ resource "aws_lambda_function" "clearDevData" {
       APP_VERSION = var.app_version
       API_VERSION = var.api_version
       NODE_ENV    = "production"
-      RUNTIME_ENV = var.target_env
+      RUNTIME_ENV = var.target_env == "dev" ? "dev" : "tools"
       DB_USER     = var.db_username
       DB_PASSWORD = data.aws_ssm_parameter.postgres_password.value
       DB_HOST     = aws_rds_cluster.pgsql.endpoint


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective: 

- manually removed this function from test and prod (no code to run the lambda has ever been deployed to these envs, but the lambda function itself had been created which could be confusing)
- update terraform file to ignore this resource on prod and test

